### PR TITLE
BZ 1077: brute-force port of original BZ 1077 diffs to node_package repo.

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -10,6 +10,7 @@ RUNNER_ETC_DIR={{runner_etc_dir}}
 RUNNER_LOG_DIR={{runner_log_dir}}
 PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
+SSL_DIST_CONFIG={{platform_data_dir}}/ssl_distribution.args_file
 
 # Extract the target node name from node.args
 NAME_ARG=`grep '\-[s]*name' $RUNNER_ETC_DIR/vm.args`
@@ -50,6 +51,11 @@ ERTS_PATH=$RUNNER_BIN_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
 NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
+
+# Scrape out SSL distribution config info from vm.args into $SSL_DIST_CONFIG
+rm -f $SSL_DIST_CONFIG
+sed -n '/Begin SSL distribution items/,/End SSL distribution items/p' \
+    $RUNNER_ETC_DIR/vm.args > $SSL_DIST_CONFIG
 
 # Function to su into correct user
 function check_user() {

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -1,4 +1,6 @@
+#!/usr/bin/env escript
 %% -*- erlang -*-
+%%! -args_file {{platform_data_dir}}/ssl_distribution.args_file
 %% -------------------------------------------------------------------
 %%
 %% nodetool: Helper Script for interacting with live nodes
@@ -6,6 +8,10 @@
 %% -------------------------------------------------------------------
 
 main(Args) ->
+    %% process_args() has side-effects (e.g. when processing "-name"),
+    %% so take care of app-starting business first.
+    [application:start(App) || App <- [crypto, public_key, ssl]],
+
     %% Extract the args
     {RestArgs, TargetNode} = process_args(Args, [], undefined),
 

--- a/priv/templates/deb/vars.config
+++ b/priv/templates/deb/vars.config
@@ -11,4 +11,10 @@
 
 {pipe_dir,           "/tmp/{{package_install_name}}/"}.
 
+% Platform-specific installation paths
+{platform_bin_dir, "/usr/sbin"}.
+{platform_data_dir, "/var/lib/{{package_install_name}}"}.
+{platform_etc_dir, "/etc/{{package_install_name}}"}.
+{platform_lib_dir, "/usr/lib/{{package_install_name}}"}.
+{platform_log_dir, "/var/log/{{package_install_name}}"}.
 

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -28,13 +28,19 @@ Obsoletes: {{package_name}}
 %setup -q -n {{package_name}}-%{_revision}
 cat > rpm.vars.config <<EOF
 {data_dir,          "%{_localstatedir}/lib/{{package_install_name}}"}.
-{runner_script_dir, "/usr/sbin"}.
+{runner_script_dir, "%{_sbindir}"}.
 {runner_bin_dir,    "%{_libdir}/{{package_install_name}}"}.
 {runner_run_dir,    "%{_localstatedir}/lib/{{package_install_name}}"}.
 {runner_etc_dir,    "%{_sysconfdir}/{{package_install_name}}"}.
 {runner_log_dir,    "%{_localstatedir}/log/{{package_install_name}}"}.
 {runner_user,       "{{package_install_user}}"}.
 {pipe_dir,          "%{_localstatedir}/run/{{package_install_name}}"}.
+% Platform-specific installation paths
+{platform_bin_dir, "%{_sbindir}"}.
+{platform_data_dir, "%{_localstatedir}/lib/%{name}"}.
+{platform_etc_dir, "%{_sysconfdir}/%{name}"}.
+{platform_lib_dir, "%{riak_lib}"}.
+{platform_log_dir, "%{_localstatedir}/log/%{name}"}.
 EOF
 
 


### PR DESCRIPTION
This is a brute-force port of original BZ 1077 diffs to node_package repo, as agreed
last week when discussing the future of nodetool packaging, BZ 1077, and other items.

I kept the duplication of the platform_\* variables and runner_\* variables to see which
Dizzy likes better.  As long as the names are consistent and their info is available in
the places that need them, I'm flexible about their actual names.
