### PR TITLE
Port changes from basho/riak into node_package

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,24 @@
 * node_package
 ** Overview
-node_package is a set of RPM/Debian/Solaris templates and scripts, suitable for packaging embedded Erlang nodes. 
+
+node_package is a set of RPM/Debian/Solaris templates and scripts, suitable for packaging embedded Erlang nodes.
+
+*** Supported Operating Systems
+
+Currently supported operating systems / distros
+ - Redhat / Fedora and variants
+ - Debian / Ubuntu and variants
+
+Planned supported operating systems
+ - Solaris
+ - FreeBSD
+ - OSX
+ - SmartOS
+
 ** Variables
+
 The following variables describe a package
+
 *** Required Variables
  - =package_name= - The name of the package
  - =package_shortdesc= - A short (< one line) description of the package
@@ -16,6 +32,7 @@ The following variables describe a package
  - =vendor_contact_name= - The name of the maintainer (ex: Basho Packaging)
  - =vendor_contact_email= - The email address of the maintainer (ex: riak@basho.com)
  - =solaris_pkgname= - Package names for Solaris follow a naming convention of MAINTapp (ex: BASHOriak)
+
 *** Optional Variables
  - =license_full_text= - If the full text of a license needs to be included, use this variable
  - =deb_depends= - Dependencies you require on deb sytems.  This should be a comma separated list.

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -91,7 +91,6 @@ check_user() {
             echoerr "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
             exit 1
         fi
-        echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
         exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
     fi
 }

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -1,7 +1,19 @@
+#!/bin/sh
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
 # installed by node_package (github.com/basho/node_package)
+
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    # To support 'whoami' add /usr/ucb to path
+    PATH=/usr/ucb:$PATH
+    export PATH
+    exec /usr/bin/ksh $0 "$@"
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}
@@ -12,9 +24,15 @@ RUNNER_ETC_DIR={{runner_etc_dir}}
 RUNNER_LOG_DIR={{runner_log_dir}}
 PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
+APP_VERSION={{app_version}}
+
+# Threshold where users will be warned of low ulimit file settings
+ULIMIT_WARN=4096
+
+WHOAMI=$(whoami)
 
 # Extract the target node name from node.args
-NAME_ARG=`grep '\-[s]*name' $RUNNER_ETC_DIR/vm.args`
+NAME_ARG=`egrep '^\-s?name' $RUNNER_ETC_DIR/vm.args`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
@@ -36,7 +54,7 @@ else
 fi
 
 # Extract the target cookie
-COOKIE_ARG=`grep '\-setcookie' $RUNNER_ETC_DIR/vm.args`
+COOKIE_ARG=`grep '^\-setcookie' $RUNNER_ETC_DIR/vm.args`
 if [ -z "$COOKIE_ARG" ]; then
     echo "vm.args needs to have a -setcookie parameter."
     exit 1
@@ -52,25 +70,32 @@ ERTS_PATH=$RUNNER_BIN_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
 NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
+NODETOOL_LITE="$ERTS_PATH/escript $ERTS_PATH/nodetool"
+
+# Ping node without stealing stdin
+ping_node() {
+    $NODETOOL ping < /dev/null
+}
 
 # Function to su into correct user
-function check_user() {
+check_user() {
     # Validate that the user running the script is the owner of the
     # RUN_DIR.
-    if [ "$RUNNER_RUN_DIR" -a ! -O "$RUNNER_RUN_DIR" ]; then
-        if [ "$LOGNAME" == "root" ]; then
-            su - $RUNNER_USER $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT -- $@
-            exit $?
-        else
-            echo "You must be $RUNNER_USER or root to invoke this script!"
+
+    if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
+        type sudo > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
             exit 1
         fi
+        echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
+        exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
     fi
 }
 
 # Function to validate the node is down
-function node_down_check() {
-    RES=`$NODETOOL ping`
+node_down_check() {
+    RES=`ping_node`
     if [ "$RES" = "pong" ]; then
         echo "Node is already running!"
         exit 1
@@ -78,10 +103,32 @@ function node_down_check() {
 }
 
 # Function to validate the node is up
-function node_up_check() {
-    RES=`$NODETOOL ping`
+node_up_check() {
+    RES=`ping_node`
     if [ "$RES" != "pong" ]; then
         echo "Node is not running!"
         exit 1
+    fi
+}
+
+# Function to check if the config file is valid
+check_config() {
+    RES=`$NODETOOL_LITE chkconfig $RUNNER_ETC_DIR/app.config`
+    if [ "$RES" != "ok" ]; then
+        echo "Error reading $RUNNER_ETC_DIR/app.config"
+        echo $RES
+        exit 1
+    fi
+    echo "config is OK"
+}
+
+# Function to check if ulimit is properly set
+check_ulimit() {
+
+    ULIMIT_F=`ulimit -n`
+    if [ "$ULIMIT_F" -lt $ULIMIT_WARN ]; then
+        echo "!!!!"
+        echo "!!!! WARNING: ulimit -n is ${ULIMIT_F}; ${ULIMIT_WARN} is the recommended minimum."
+        echo "!!!!"
     fi
 }

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -31,10 +31,13 @@ ULIMIT_WARN=4096
 
 WHOAMI=$(whoami)
 
+# Echo to stderr on errors
+echoerr() { echo "$@" 1>&2; }
+
 # Extract the target node name from node.args
 NAME_ARG=`egrep '^\-s?name' $RUNNER_ETC_DIR/vm.args`
 if [ -z "$NAME_ARG" ]; then
-    echo "vm.args needs to have either -name or -sname parameter."
+    echoerr "vm.args needs to have either -name or -sname parameter."
     exit 1
 fi
 
@@ -56,7 +59,7 @@ fi
 # Extract the target cookie
 COOKIE_ARG=`grep '^\-setcookie' $RUNNER_ETC_DIR/vm.args`
 if [ -z "$COOKIE_ARG" ]; then
-    echo "vm.args needs to have a -setcookie parameter."
+    echoerr "vm.args needs to have a -setcookie parameter."
     exit 1
 fi
 
@@ -85,7 +88,7 @@ check_user() {
     if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
         type sudo > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
+            echoerr "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
             exit 1
         fi
         echo "Attempting to restart script through sudo -H -u $RUNNER_USER"
@@ -97,7 +100,7 @@ check_user() {
 node_down_check() {
     RES=`ping_node`
     if [ "$RES" = "pong" ]; then
-        echo "Node is already running!"
+        echoerr "Node is already running!"
         exit 1
     fi
 }
@@ -106,7 +109,7 @@ node_down_check() {
 node_up_check() {
     RES=`ping_node`
     if [ "$RES" != "pong" ]; then
-        echo "Node is not running!"
+        echoerr "Node is not running!"
         exit 1
     fi
 }
@@ -115,8 +118,8 @@ node_up_check() {
 check_config() {
     RES=`$NODETOOL_LITE chkconfig $RUNNER_ETC_DIR/app.config`
     if [ "$RES" != "ok" ]; then
-        echo "Error reading $RUNNER_ETC_DIR/app.config"
-        echo $RES
+        echoerr "Error reading $RUNNER_ETC_DIR/app.config"
+        echoerr $RES
         exit 1
     fi
     echo "config is OK"

--- a/priv/base/erl
+++ b/priv/base/erl
@@ -1,4 +1,13 @@
-#!/bin/bash
+#!/bin/sh
+
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 "$@"
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 
 ## This script replaces the default "erl" in erts-VSN/bin. This is necessary
 ## as escript depends on erl and in turn, erl depends on having access to a

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -1,4 +1,6 @@
-%% -*- erlang -*-
+#!/usr/bin/env escript
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
 %% -------------------------------------------------------------------
 %%
 %% nodetool: Helper Script for interacting with live nodes
@@ -8,6 +10,7 @@
 %% installed by node_package (github.com/basho/node_package)
 
 main(Args) ->
+    ok = start_epmd(),
     %% Extract the args
     {RestArgs, TargetNode} = process_args(Args, [], undefined),
 
@@ -19,11 +22,33 @@ main(Args) ->
                          Value
                  end,
 
+    %% process_args() has side-effects (e.g. when processing "-name"),
+    %% so take care of app-starting business first.
+    [application:start(App) || App <- [crypto, public_key, ssl]],
+
+    %% any commands that don't need a running node
+    case RestArgs of
+        ["chkconfig", File] ->
+            case file:consult(File) of
+                {ok, _} ->
+                    io:format("ok\n"),
+                    halt(0);
+                {error, {Line, Mod, Term}} ->
+                    io:format(["Error on line ", file:format_error({Line, Mod, Term}), "\n"]),
+                    halt(1);
+                {error, R} ->
+                    io:format(["Error reading config file: ", file:format_error(R), "\n"]),
+                    halt(1)
+            end;
+        _ ->
+            ok
+    end,
+
     %% See if the node is currently running  -- if it's not, we'll bail
     case {net_kernel:hidden_connect_node(TargetNode), net_adm:ping(TargetNode)} of
-        {true, pong} -> 
+        {true, pong} ->
             ok;
-        {_, pang} -> 
+        {_, pang} ->
             io:format("Node ~p not responding to pings.\n", [TargetNode]),
             halt(1)
     end,
@@ -50,6 +75,16 @@ main(Args) ->
                 _ ->
                     halt(1)
             end;
+        ["rpc_infinity", Module, Function | RpcArgs] ->
+            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function), [RpcArgs], infinity)
+                ok ->
+                    ok;
+                {badrpc, Reason} ->
+                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    halt(1);
+                _ ->
+                    halt(1)
+            end;
         ["rpcterms", Module, Function, ArgsAsString] ->
             case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
                           consult(ArgsAsString), RpcTimeout) of
@@ -61,10 +96,10 @@ main(Args) ->
             end;
         Other ->
             io:format("Other: ~p\n", [Other]),
-            io:format("Usage: nodetool {ping|stop|restart|reboot}\n")
+            io:format("Usage: nodetool {ping|stop|restart|reboot|chkconfig}\n")
     end,
     net_kernel:stop().
-    
+
 process_args([], Acc, TargetNode) ->
     {lists:reverse(Acc), TargetNode};
 process_args(["-setcookie", Cookie | Rest], Acc, TargetNode) ->
@@ -87,6 +122,27 @@ process_args(["-rpctimeout", TimeoutStr | Rest], Acc, TargetNode) ->
     process_args(Rest, Acc, TargetNode);
 process_args([Arg | Rest], Acc, Opts) ->
     process_args(Rest, [Arg | Acc], Opts).
+
+
+start_epmd() ->
+    [] = os:cmd(epmd_path() ++ " -daemon"),
+    ok.
+
+epmd_path() ->
+    ErtsBinDir = filename:dirname(escript:script_name()),
+    Name = "epmd",
+    case os:find_executable(Name, ErtsBinDir) of
+        false ->
+            case os:find_executable(Name) of
+                false ->
+                    io:format("Could not find epmd.~n"),
+                    halt(1);
+                GlobalEpmd ->
+                    GlobalEpmd
+            end;
+        Epmd ->
+            Epmd
+    end.
 
 
 nodename(Name) ->

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -76,7 +76,7 @@ main(Args) ->
                     halt(1)
             end;
         ["rpc_infinity", Module, Function | RpcArgs] ->
-            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function), [RpcArgs], infinity)
+            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function), [RpcArgs], infinity) of
                 ok ->
                     ok;
                 {badrpc, Reason} ->

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -18,9 +18,17 @@ case "$1" in
     start)
         # Make sure there is not already a node running
         node_down_check
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
 
         # Sanity check the app.config file
-        check_config
+        check_config > /dev/null
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
 
         HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
         export HEART_COMMAND
@@ -98,6 +106,10 @@ case "$1" in
         else
           # Make sure a node is running
           node_up_check
+          ES=$?
+          if [ "$ES" -ne 0 ]; then
+              exit $ES
+          fi
         fi
 
         shift
@@ -113,6 +125,10 @@ case "$1" in
 
         # Sanity check the app.config file
         check_config
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
 
         # Warn the user if ulimit -n is less than the defined threshold
         check_ulimit

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -5,7 +5,7 @@
 # installed by node_package (github.com/basho/node_package)
 
 # Pull environment for this install
-source {{runner_bin_dir}}/lib/env.sh
+. {{runner_bin_dir}}/lib/env.sh
 
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -9,6 +9,11 @@
 
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@
+ES=$?
+if [ "$ES" -ne 0 ]; then
+    exit $ES
+fi
+
 
 # Make sure CWD is set to runner run dir
 cd $RUNNER_RUN_DIR
@@ -29,6 +34,9 @@ case "$1" in
         if [ "$ES" -ne 0 ]; then
             exit $ES
         fi
+
+        # Warn the user if ulimit is too low
+        check_ulimit
 
         HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
         export HEART_COMMAND

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
@@ -16,8 +16,11 @@ cd $RUNNER_RUN_DIR
 # Check the first argument for instructions
 case "$1" in
     start)
+        # Make sure there is not already a node running
         node_down_check
 
+        # Sanity check the app.config file
+        check_config
 
         HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
         export HEART_COMMAND
@@ -34,6 +37,7 @@ case "$1" in
                 # some reason.
                 COMMAND_MODE=unix2003
         esac
+
         # Wait for the node to completely stop...
         case $UNAME_S in
             Linux|Darwin|FreeBSD|DragonFly|NetBSD|OpenBSD)
@@ -47,8 +51,14 @@ case "$1" in
                     grep "$RUNNER_BIN_DIR/.*/[b]eam"|awk '{print $1}'`
                 ;;
         esac
+
         $NODETOOL stop
-        while `kill -0 $PID 2>/dev/null`;
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
+
+        while `kill -s 0 $PID 2>/dev/null`;
         do
             sleep 1
         done
@@ -57,39 +67,55 @@ case "$1" in
     restart)
         ## Restart the VM without exiting the process
         $NODETOOL restart
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
         ;;
 
     reboot)
         ## Restart the VM completely (uses heart to restart it)
         $NODETOOL reboot
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
         ;;
 
     ping)
         ## See if the VM is alive
-        $NODETOOL ping
+        ping_node
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
         ;;
 
     attach)
-        node_up_check
+        # Allow attaching to a node without pinging it
+        if [ "$2" = "-f" ]; then
+          echo "Forcing connection..."
+        else
+          # Make sure a node is running
+          node_up_check
+        fi
 
         shift
-        $ERTS_PATH/to_erl $PIPE_DIR
+        exec $ERTS_PATH/to_erl $PIPE_DIR
         ;;
 
     console)
-        RES=`$NODETOOL ping`
+        RES=`ping_node`
         if [ "$RES" = "pong" ]; then
             echo "Node is already running - use '$SCRIPT attach' instead"
             exit 1
         fi
 
-        # Warn the user if ulimit -n is less than 1024
-        ULIMIT_F=`ulimit -n`
-        if [ "$ULIMIT_F" -lt 4096 ]; then
-            echo "!!!!"
-            echo "!!!! WARNING: ulimit -n is ${ULIMIT_F}; 1024 is the recommended minimum."
-            echo "!!!!"
-        fi
+        # Sanity check the app.config file
+        check_config
+
+        # Warn the user if ulimit -n is less than the defined threshold
+        check_ulimit
 
         # Make sure log directory exists
         mkdir -p $RUNNER_LOG_DIR
@@ -121,9 +147,19 @@ case "$1" in
     ertspath)
         echo $ERTS_PATH
         ;;
+    chkconfig)
+        check_config
+        ;;
+    escript)
+        shift
+        $ERTS_PATH/escript "$@"
+        ;;
+    version)
+        echo $APP_VERSION
+        ;;
 
     *)
-        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|console|attach}"
+        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|console|attach|ertspath|chkconfig|escript|version}"
         exit 1
         ;;
 esac

--- a/src/node_package.app.src
+++ b/src/node_package.app.src
@@ -3,7 +3,7 @@
 
 {application, node_package,
  [{description, "RPM/Debian/Solaris packaging templates for Erlang Nodes"},
-  {vsn, "0.2.2"},
+  {vsn, "1.0.0"},
   {modules, []},
   {registered, []},
   {applications, []}


### PR DESCRIPTION
# Changes

Many bug fixes and useability changes have happened in Riak
that needed to be copied over to node_package. The major change
was to specify `/bin/sh` as the shell to enable node_package
use on systems which don't ship with `bash` namely Solaris.

In addition, node_package used LOGNAME in its scripts which
was found to be unreliable across platforms in Riak. Changes
were made to use whois instead to fix #10.
# Bugs / Issues Fixed

Fixes: #10 #12
# Testing

The package was tested by doing the following on an Ubuntu 12.04 clean install with Riak installed
- Change basho/stanchion `rebar.config` to point to branch `gh12-xplatform-support`
- `make package RELEASE=1`
- Make sure `riak` is installed
- `sudo dpkg -i <stanchion pkg>`
- Ensure the following work
  - `stanchion start`
  - `stanchion ping`
  - ensure `stanchion console` errors and tells you to `stanchion attach`
  - `stanchion attach`
  - `stanchion stop`
  - ensure `stanchion ping` fails
  - change the `/etc/stanchion/app.config` to have a syntax error (I added a "." randomly)
  - ensure `stanchion chkconfig` and `stanchion start` both error out
# Known Issues
- `appname version` does not work yet
- `appname reboot` does not work, see #16
