### PR TITLE
Make sure the log directory exists when using the runner start command

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -37,6 +37,9 @@ case "$1" in
         # Warn the user if ulimit is too low
         check_ulimit
 
+        # Make sure log directory exists
+        mkdir -p $RUNNER_LOG_DIR
+
         HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
         export HEART_COMMAND
         mkdir -p $PIPE_DIR


### PR DESCRIPTION
This addresses a problem I ran into when trying to run `riak_test` and a `git clean -fd` removes the log directory and caused subsequent test runs to fail.
