### PR TITLE
Add top command to runner script

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -169,7 +169,23 @@ case "$1" in
         # Start the VM
         exec $CMD
         ;;
-
+    top)
+        # Make sure the local node IS running
+        RES=`ping_node`
+        if [ "$RES" != "pong" ]; then
+            echo "Node is not running!"
+            exit 1
+        fi
+        shift
+        MYPID=$$
+        NODE_NAME=${NAME_ARG#* }
+        $ERTS_PATH/erl -noshell -noinput \
+            -pa $RUNNER_LIB_DIR/basho-patches \
+            -hidden $NAME_PARAM np_etop$MYPID$NAME_HOST $COOKIE_ARG \
+            -s etop -s erlang halt -output text \
+            -node $NODE_NAME \
+            $* -tracing off
+        ;;
     ertspath)
         echo $ERTS_PATH
         ;;
@@ -185,7 +201,9 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|console|attach|ertspath|chkconfig|escript|version}"
+        echo "Usage: $SCRIPT {start | stop| restart| reboot| ping| console| attach| "
+        echo "                    ertspath| chkconfig| escript| version | "
+        echo "                    top [-interval N] [-sort reductions|memory|msg_q] [-lines N] }"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Enable all `node_package` apps to be able to use `etop` out of the box.
This differs from the way Riak currently works since it has a separate
command line tool to run top, but I would favor moving towards a
single tool with more robust functionality.
