### PR TITLE
Clarify bin_or_sbin semantics

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,10 +9,10 @@ packaging embedded Erlang nodes.
 Currently supported operating systems / distros
  - Redhat / Fedora and variants
  - Debian / Ubuntu and variants
-
-Planned supported operating systems
  - FreeBSD
  - OSX
+
+Planned supported operating systems
  - SmartOS
 
 ** Use
@@ -75,3 +75,5 @@ The following variables describe a package
    this value.  This defaults to 4096 in all packages.
  - =platform_patch_dir= - Directory to include in erlang's load path to allow for
    patches to be hotloaded.  (ex: {platform_lib_dir}/basho-patches)
+ - =bin_or_sbin= - Tells where to put the binaries, in */bin or */sbin
+   (default: bin)

--- a/priv/templates/deb/dirs
+++ b/priv/templates/deb/dirs
@@ -2,7 +2,7 @@ etc/init.d
 etc/{{package_install_name}}
 etc/logrotate.d
 usr/lib/{{package_install_name}}
-usr/sbin
+usr/{{bin_or_sbin}}
 usr/share/man/man1
 var/run/{{package_install_name}}
 var/lib/{{package_install_name}}

--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -11,7 +11,7 @@
 
 DESC="{{package_shortdesc}}"
 NAME={{package_install_name}}
-DAEMON=/usr/sbin/$NAME
+DAEMON=/usr/{{bin_or_sbin}}/$NAME
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Read configuration variable file if it is present

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -43,9 +43,9 @@ install: build
               debian/{{package_name}}/usr/lib/{{package_install_name}}
 
 ## executables
-	if [ -d rel/{{package_install_name}}/{{bin_or_sbin}} ]; then \
+	if [ -d rel/{{package_install_name}}/bin ]; then \
 	    mkdir -p debian/{{package_name}}/usr/{{bin_or_sbin}} && \
-	    {{#package_commands}}install -p -D -m 0755 rel/{{package_install_name}}/{{bin_or_sbin}}/{{name}} debian/{{package_name}}/usr/{{bin_or_sbin}}/ && \
+	    {{#package_commands}}install -p -D -m 0755 rel/{{package_install_name}}/bin/{{name}} debian/{{package_name}}/usr/{{bin_or_sbin}}/ && \
 	    {{/package_commands}}echo -n; fi
 
 ## man pages

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -130,7 +130,7 @@ $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
 	mkdir -p $(PBIN_DIR)
-	cp -R rel/{{package_install_name}}/{{bin_or_sbin}}/* $(PBIN_DIR)
+	cp -R rel/{{package_install_name}}/bin/* $(PBIN_DIR)
 	mkdir -p $(PETC_DIR)
 	cp -R rel/{{package_install_name}}/etc/* $(PETC_DIR)
 	mkdir -p $(PLIB_DIR)
@@ -151,7 +151,7 @@ buildrel:
 	# make the app version available for templating
 	echo "{app_version, \"$(PKG_VERSION)\"}." >> $(PKGERDIR)/vars.config
 	OVERLAY_VARS="overlay_vars=../fbsd/vars.config" $(MAKE) deps rel
-	chmod 0755 rel/{{package_install_name}}/{{bin_or_sbin}}/* rel/{{package_install_name}}/erts-*/bin/*
+	chmod 0755 rel/{{package_install_name}}/bin/* rel/{{package_install_name}}/erts-*/bin/*
 
 $(BUILDDIR):
 	mkdir -p $@

--- a/priv/templates/fbsd/fbsd.template
+++ b/priv/templates/fbsd/fbsd.template
@@ -7,15 +7,15 @@
              {package_install_user, "package_install_user"},
              {package_install_user_desc, "package_install_user_desc"},
              {package_install_group, "package_install_group"},
+             {bin_or_sbin, "bin"},
 
              %% Platform-specific installation paths
-             {platform_bin_dir,  "/usr/local/sbin"},
+             {platform_bin_dir,  "/usr/local/{{bin_or_sbin}}"},
              {platform_data_dir, "/var/db/{{package_install_name}}"},
              {platform_etc_dir,  "/usr/local/etc/{{package_install_name}}"},
              {platform_base_dir, "/usr/local/lib/{{package_install_name}}"},
              {platform_lib_dir,  "/usr/local/lib/{{package_install_name}}/lib"},
              {platform_log_dir,  "/var/log/{{package_install_name}}"},
-             {bin_or_sbin, "bin"},
              {runner_ulimit_warn, "4096"}
              ]
 }.

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -16,10 +16,10 @@ RETVAL=0
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="{{package_shortdesc}}"
 NAME={{package_install_name}}
-DAEMON=/usr/sbin/$NAME
+DAEMON=/usr/{{bin_or_sbin}}/$NAME
 
 # Check for script, config and data dirs
-[ -x /usr/sbin/$NAME ] || exit 0
+[ -x /usr/{{bin_or_sbin}}/$NAME ] || exit 0
 [ -d /etc/$NAME ] || exit 0
 [ -d /var/lib/$NAME ] || exit 0
 [ -d /var/run/$NAME ] || exit 0

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -70,8 +70,8 @@ cp -R %{relpath}/erts-*    %{buildroot_lib}
 cp -R %{relpath}/releases  %{buildroot_lib}
 
 mkdir -p %{buildroot}%{_{{bin_or_sbin}}dir}
-if [ -d %{relpath}/{{bin_or_sbin}} ]; then \
-   find %{relpath}/{{bin_or_sbin}} -type f \
+if [ -d %{relpath}/bin ]; then \
+   find %{relpath}/bin -type f \
         -exec install -p -D -m 0755 {} %{buildroot}%{_{{bin_or_sbin}}dir}/ \; ;fi
 
 mkdir -p %{buildroot}%{_mandir}/man1


### PR DESCRIPTION
Erlang's reltool always creates a `bin` directory when creating
a rel.  So packages using reltool and node_package should only
have binaries in `rel/bin`.

See:
basho/stanchion#38
basho/riak_cs#409
