### PR TITLE
Replace incorrect cases of packag_name verus package_install_name

### DIFF
--- a/priv/templates/rpm/Makefile
+++ b/priv/templates/rpm/Makefile
@@ -15,9 +15,9 @@ default:
 		 --define "_revision $(PKG_VERSION)" \
 		 --define "_version $(PKG_VERSION)" \
 		 --define "_release $(PKG_BUILD)" \
+		 --define "_tarname $(PKG_ID).tar.gz" \
 		 -ba $(PWD)/specfile
 	cd packages && \
 		for rpmfile in `ls *.rpm`; do \
 			sha256sum $${rpmfile} > $${rpmfile}.sha \
 		; done
-

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -32,7 +32,7 @@ Obsoletes: {{package_name}}
 %define platform_log_dir %{_localstatedir}/log/{{package_install_name}}
 
 %prep
-%setup -q -n {{package_name}}-%{_revision}
+%setup -q -n {{package_install_name}}-%{_revision}
 cat > rpm.vars.config <<EOF
 %% Platform-specific installation paths
 {platform_bin_dir,  "%{platform_bin_dir}"}.

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -9,7 +9,7 @@ Version: %{_version}
 Release: %{_release}%{?dist}
 License: {{license_type}}
 Group: Development/Libraries
-Source: %{name}-%{_revision}.tar.gz
+Source: %{_tarname}
 URL: {{vendor_url}}
 Vendor: {{vendor_name}}
 Packager: {{vendor_contact_name}} <{{vendor_contact_email}}>

--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -26,8 +26,8 @@ buildrel:
 	@# Ye Olde Bourne Shell on Solaris means we have to do it old school
 	echo "Using `which erl` to build"; \
 	OVERLAY_VARS="overlay_vars=../solaris/vars.config" $(MAKE) deps rel
-	chmod 0755 rel/{{package_name}}/bin/* \
-		rel/{{package_name}}/erts-*/bin/*
+	chmod 0755 rel/$(PKG_ID)/bin/* \
+		rel/$(PKG_ID)/erts-*/bin/*
 
 depend:
 	cp $(PKGERDIR)/depend .

--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -26,8 +26,8 @@ buildrel:
 	@# Ye Olde Bourne Shell on Solaris means we have to do it old school
 	echo "Using `which erl` to build"; \
 	OVERLAY_VARS="overlay_vars=../solaris/vars.config" $(MAKE) deps rel
-	chmod 0755 rel/$(PKG_ID)/bin/* \
-		rel/$(PKG_ID)/erts-*/bin/*
+	chmod 0755 rel/{{package_install_name}}/bin/* \
+		rel/{{package_install_name}}/erts-*/bin/*
 
 depend:
 	cp $(PKGERDIR)/depend .
@@ -46,7 +46,7 @@ prototype:
 	echo "i i.preserve" >> prototype
 	echo "i r.preserve" >> prototype
 	echo '' >> prototype
-	pkgproto rel/{{package_name}}={{package_name}} >> prototype
+	pkgproto rel/{{package_install_name}}={{package_install_name}} >> prototype
 	sed -e "s/ $(LOGNAME) .*$$/ {{package_install_user}} {{package_install_group}}/" \
 	    -e 's/f none {{package_install_name}}\/etc/e preserve {{package_install_name}}\/etc/' prototype > prototype.tmp && mv prototype.tmp prototype
 


### PR DESCRIPTION
There were still some places where `package_name` was used instead of `package_install_name`.  This problem was brought to light when Riak CS EE had a `package_name` of "riak-cs-ee" and `package_install_name` of "riak-cs".
