### PR TITLE
Convert RPM init script to fall in line with Redhat style

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -123,12 +123,14 @@ case "$1" in
             exit $ES
         fi
 
+        # Tell nodetool to stop
         $NODETOOL stop
         ES=$?
         if [ "$ES" -ne 0 ]; then
             exit $ES
         fi
 
+        # Now wait for the app to *really* stop
         while `kill -s 0 $PID 2>/dev/null`;
         do
             sleep 1

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -137,7 +137,7 @@ case "$1" in
         $DAEMON ping || exit $?
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|try-restart|ping}"
+        echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|try-restart|status|ping}"
         exit 1
 esac
 

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -17,6 +17,8 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="{{package_shortdesc}}"
 NAME={{package_install_name}}
 DAEMON=/usr/{{bin_or_sbin}}/$NAME
+lockfile=/var/lock/subsys/$NAME
+pidfile=/var/run/$NAME.pid
 
 # Check for script, config and data dirs
 [ -x /usr/{{bin_or_sbin}}/$NAME ] || exit 0
@@ -24,60 +26,120 @@ DAEMON=/usr/{{bin_or_sbin}}/$NAME
 [ -d /var/lib/$NAME ] || exit 0
 [ -d /var/run/$NAME ] || exit 0
 
+status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
+running=$?
+
+check_pid_status() {
+	pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+    if [ "$pid" = "" ]; then
+        # prog not running?
+        return 1
+    else
+        # running
+        return 0
+    fi
+}
 
 start() {
-        # Start daemons.
-        echo -n $"Starting {{package_install_name}}: "
-        su - {{package_install_user}} -c "$DAEMON start" && success || failure $"$NAME start"
-        RETVAL=$?
-        [ $RETVAL -eq 0 ]
-        echo
-        return $RETVAL
+	# Start daemons.
+	echo -n $"Starting {{package_install_name}}: "
+	su - {{package_install_user}} -c "$DAEMON start"
+	RETVAL=$?
+	if [ $RETVAL -eq 0 ]; then
+		pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+		echo "$pid" > $pidfile
+		touch $lockfile
+		success
+	else
+		failure $"$NAME start"
+	fi
+	echo
+	return $RETVAL
 }
 
 stop() {
-        # Stop daemon.
-        echo -n $"Stopping {{package_install_name}}: "
-        $DAEMON stop 2>/dev/null 1>&2
-        sleep 2
-        # Check if the process is still running, muting output of getpid
-        MUTE=`$DAEMON getpid`
-        [ "$?" -ne 0 ] && success && echo && return 0 || failure $"$NAME stop"
-        sleep 10
-        MUTE=`$DAEMON getpid`
-        [ "$?" -ne 0] && success && echo && return 0 || failure $"$NAME failed to stop"
-        echo
-        return 1
-
+	# Stop daemon.
+	echo -n $"Shutting down {{package_install_name}}: "
+	$DAEMON stop 2>/dev/null 1>&2
+	for n in $(seq 1 10); do
+		sleep 1
+		check_pid_status
+		RETVAL=$?
+		if [ $RETVAL -eq 1 ]; then
+			break
+		fi
+	done
+	if [ $retval -eq 1 ]; then
+		rm -f $lockfile $pidfile
+		success
+	else
+		failure $"$NAME stop"
+	fi
+	echo
+	return $retval
 }
 
-status() {
-        # Check status of daemon
-        $DAEMON ping && success && echo $"$NAME is running..." && return 0 || failure $"$NAME is stopped"
-        return 2
+hardstop() {
+	echo -n $"Shutting down $NAME: "
+	su - {{packge_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
+	for n in $(seq 1 10); do
+		sleep 1
+		check_pid_status
+		RETVAL=$?
+		if [ $RETVAL -eq 1 ]; then
+			break
+		fi
+	done
+	if [ $RETVAL -eq 1 ]; then
+		rm -f $lockfile $pidfile
+		success
+	else
+		failure $"$NAME stop"
+	fi
+	echo
+	return $RETVAL
 }
 
 # See how we were called.
 case "$1" in
-  start)
-        start
-        ;;
-  stop)
-        stop
-        ;;
-  restart)
-        stop
-        start
-        ;;
-  ping)
-        $DAEMON ping || exit $?
-        ;;
-  status)
-        status && exit 0 || exit $?
-        ;;
-  *)
-        echo $"Usage: $0 {start|stop|restart|ping|status}"
-        exit 1
+	start)
+		[ $running -eq 0 ] && exit 0
+		start
+		;;
+	stop)
+		if [ $running -eq 0 ]; then
+			stop
+		else
+			check_pid_status
+			RETVAL=$?
+			if [ $RETVAL -eq 1 ]; then
+				rm -f $lockfile $pidfile
+			fi
+			exit 0
+		fi
+		;;
+	restart|force-reload)
+		[ $running -eq 0 ] && stop
+		start
+		;;
+	hardstop)
+		[ $running -eq 0 ] || exit 0
+		hardstop
+		;;
+	condrestart)
+		[ $running -eq 0 ] || exit 0
+		stop
+		start
+		;;
+	status)
+		status -p $pidfile -l $(basename $lockfile) $NAME
+		;;
+	ping)
+		$DAEMON ping || exit $?
+		;;
+	*)
+		echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|ping}"
+		exit 1
 esac
 
 exit $?

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -18,13 +18,12 @@ DESC="{{package_shortdesc}}"
 NAME={{package_install_name}}
 DAEMON=/usr/{{bin_or_sbin}}/$NAME
 lockfile=/var/lock/subsys/$NAME
-pidfile=/var/run/$NAME.pid
+pidfile=/var/run/$NAME/$NAME.pid
 
 # Check for script, config and data dirs
 [ -x /usr/{{bin_or_sbin}}/$NAME ] || exit 0
 [ -d /etc/$NAME ] || exit 0
 [ -d /var/lib/$NAME ] || exit 0
-[ -d /var/run/$NAME ] || mkdir /var/run/$NAME || exit 0
 
 status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
@@ -79,7 +78,7 @@ stop() {
 
 hardstop() {
     echo -n $"Shutting down $NAME: "
-    su - {{packge_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
+    su - {{package_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
     for n in $(seq 1 10); do
         sleep 1
         check_pid_status

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # {{package_name}}
 #
@@ -30,7 +30,7 @@ status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
 
 check_pid_status() {
-	pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
     if [ "$pid" = "" ]; then
         # prog not running?
         return 1
@@ -41,105 +41,104 @@ check_pid_status() {
 }
 
 start() {
-	# Start daemons.
-	echo -n $"Starting {{package_install_name}}: "
-	su - {{package_install_user}} -c "$DAEMON start"
-	RETVAL=$?
-	if [ $RETVAL -eq 0 ]; then
-		pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
-		echo "$pid" > $pidfile
-		touch $lockfile
-		success
-	else
-		failure $"$NAME start"
-	fi
-	echo
-	return $RETVAL
+    # Start daemons.
+    echo -n $"Starting {{package_install_name}}: "
+    su - {{package_install_user}} -c "$DAEMON start"
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+        pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+        echo "$pid" > $pidfile
+        touch $lockfile
+        success
+    else
+        failure $"$NAME start"
+    fi
+    echo
+    return $RETVAL
 }
 
 stop() {
-	# Stop daemon.
-	echo -n $"Shutting down {{package_install_name}}: "
-	$DAEMON stop 2>/dev/null 1>&2
-	for n in $(seq 1 10); do
-		sleep 1
-		check_pid_status
-		RETVAL=$?
-		if [ $RETVAL -eq 1 ]; then
-			break
-		fi
-	done
-	if [ $retval -eq 1 ]; then
-		rm -f $lockfile $pidfile
-		success
-	else
-		failure $"$NAME stop"
-	fi
-	echo
-	return $RETVAL
+    # Stop daemon.
+    echo -n $"Shutting down {{package_install_name}}: "
+    $DAEMON stop 2>/dev/null 1>&2
+    for n in $(seq 1 10); do
+        sleep 1
+        check_pid_status
+        RETVAL=$?
+        if [ $RETVAL -eq 1 ]; then
+            break
+        fi
+    done
+    if [ $retval -eq 1 ]; then
+        rm -f $lockfile $pidfile
+        success
+    else
+        failure $"$NAME stop"
+    fi
+    echo
+    return $RETVAL
 }
 
 hardstop() {
-	echo -n $"Shutting down $NAME: "
-	su - {{packge_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
-	for n in $(seq 1 10); do
-		sleep 1
-		check_pid_status
-		RETVAL=$?
-		if [ $RETVAL -eq 1 ]; then
-			break
-		fi
-	done
-	if [ $RETVAL -eq 1 ]; then
-		rm -f $lockfile $pidfile
-		success
-	else
-		failure $"$NAME stop"
-	fi
-	echo
-	return $RETVAL
+    echo -n $"Shutting down $NAME: "
+    su - {{packge_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
+    for n in $(seq 1 10); do
+        sleep 1
+        check_pid_status
+        RETVAL=$?
+        if [ $RETVAL -eq 1 ]; then
+            break
+        fi
+    done
+    if [ $RETVAL -eq 1 ]; then
+        rm -f $lockfile $pidfile
+        success
+    else
+        failure $"$NAME stop"
+    fi
+    echo
+    return $RETVAL
 }
 
 # See how we were called.
 case "$1" in
-	start)
-		[ $running -eq 0 ] && exit 0
-		start
-		;;
-	stop)
-		if [ $running -eq 0 ]; then
-			stop
-		else
-			check_pid_status
-			RETVAL=$?
-			if [ $RETVAL -eq 1 ]; then
-				rm -f $lockfile $pidfile
-			fi
-			exit 0
-		fi
-		;;
-	restart|force-reload)
-		[ $running -eq 0 ] && stop
-		start
-		;;
-	hardstop)
-		[ $running -eq 0 ] || exit 0
-		hardstop
-		;;
-	condrestart)
-		[ $running -eq 0 ] || exit 0
-		stop
-		start
-		;;
-	status)
-		status -p $pidfile -l $(basename $lockfile) $NAME
-		;;
-	ping)
-		$DAEMON ping || exit $?
-		;;
-	*)
-		echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|ping}"
-		exit 1
+    start)
+        [ $running -eq 0 ] && exit 0
+        start
+        ;;
+    stop)
+        if [ $running -eq 0 ]; then
+            stop
+        else
+            check_pid_status
+            RETVAL=$?
+            if [ $RETVAL -eq 1 ]; then
+                rm -f $lockfile $pidfile
+            fi
+            exit 0
+        fi
+        ;;
+    restart|force-reload)
+        [ $running -eq 0 ] && stop
+        start
+        ;;
+    hardstop)
+        [ $running -eq 0 ] || exit 0
+        hardstop
+        ;;
+    condrestart|try-restart)
+        [ $running -eq 0 ] || exit 0
+        restart
+        ;;
+    status)
+        status -p $pidfile -l $(basename $lockfile) $NAME
+        ;;
+    ping)
+        $DAEMON ping || exit $?
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|try-restart|ping}"
+        exit 1
 esac
 
 exit $?

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -69,7 +69,7 @@ stop() {
             break
         fi
     done
-    if [ $retval -eq 1 ]; then
+    if [ $RETVAL -eq 1 ]; then
         rm -f $lockfile $pidfile
         success
     else

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -46,8 +46,6 @@ start() {
     su - {{package_install_user}} -c "$DAEMON start"
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then
-        pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
-        echo "$pid" > $pidfile
         touch $lockfile
         success
     else

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -24,7 +24,7 @@ pidfile=/var/run/$NAME.pid
 [ -x /usr/{{bin_or_sbin}}/$NAME ] || exit 0
 [ -d /etc/$NAME ] || exit 0
 [ -d /var/lib/$NAME ] || exit 0
-[ -d /var/run/$NAME ] || exit 0
+[ -d /var/run/$NAME ] || mkdir /var/run/$NAME || exit 0
 
 status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
@@ -76,7 +76,7 @@ stop() {
 		failure $"$NAME stop"
 	fi
 	echo
-	return $retval
+	return $RETVAL
 }
 
 hardstop() {

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -42,7 +42,7 @@ check_pid_status() {
 start() {
     # Start daemons.
     echo -n $"Starting {{package_install_name}}: "
-    su - {{package_install_user}} -c "$DAEMON start"
+    $DAEMON start
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then
         touch $lockfile
@@ -57,7 +57,7 @@ start() {
 stop() {
     # Stop daemon.
     echo -n $"Shutting down {{package_install_name}}: "
-    $DAEMON stop 2>/dev/null 1>&2
+    $DAEMON stop 2>/dev/null
     for n in $(seq 1 10); do
         sleep 1
         check_pid_status
@@ -91,7 +91,7 @@ hardstop() {
         rm -f $lockfile $pidfile
         success
     else
-        failure $"$NAME stop"
+        failure $"$NAME hardstop"
     fi
     echo
     return $RETVAL


### PR DESCRIPTION
This pull request changes the init script installed by RPM's to fall in line with Redhat and Fedora style guides.  Pid files have been added for start/stop/status functions.
