### PR TITLE
Create .pid files for package builds

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -130,8 +130,10 @@ create_pid_file() {
     # Validate a pid directory even exists
     if [ -w $PID_DIR ]; then
         # Grab the proper pid from getpid
-        if [ ! getpid ]; then
-            return 1
+        get_pid
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            return $ES
         else
             # Remove pid file if it already exists since we do not
             # plan for multiple identical runners on a single machine
@@ -148,7 +150,7 @@ create_pid_file() {
 check_user() {
     # Validate that the user running the script is the owner of the
     # RUN_DIR.
-    if ([ "$RUNNER_USER" ] && [ -w $RUN_DIR ]); then
+    if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
         type sudo > /dev/null 2>&1
         if [ "$?" -ne 0 ]; then
             echoerr "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -27,6 +27,13 @@ PIPE_DIR={{pipe_dir}}
 RUNNER_USER={{runner_user}}
 APP_VERSION={{app_version}}
 
+# Variables needed to support creation of .pid files
+# PID directory and pid file name of this app
+# ex: /var/run/riak & /var/run/riak/riak.pid
+RUN_DIR="/var/run" # for now hard coded unless we find a platform that differs
+PID_DIR=$RUN_DIR/$RUNNER_SCRIPT
+PID_FILE=$PID_DIR/$RUNNER_SCRIPT.pid
+
 # Threshold where users will be warned of low ulimit file settings
 # default it if it is not set
 ULIMIT_WARN={{runner_ulimit_warn}}
@@ -88,12 +95,60 @@ ping_node() {
     $NODETOOL ping < /dev/null
 }
 
+# Attempts to create a pid directory like /var/run/APPNAME and then
+# changes the permissions on that directory so the RUNNER_USER can
+# read/write/delete .pid files during startup/shutdown
+create_pid_dir() {
+    # Validate RUNNER_USER is set and they have permissions to write to /var/run
+    if ([ "$RUNNER_USER" ] && [ -w $RUN_DIR ]); then
+        if [ ! mkdir -p $PID_DIR]; then
+            return 1
+        else
+            # Change permissions on $PID_DIR
+            if [ ! chown $RUNNER_USER $PID_DIR]; then
+                return 1
+            else
+                return 0
+            fi
+        fi
+    fi
+
+    # If RUNNER_USER is not set this is probably a test setup (devrel) and does
+    # not need a .pid file, so do not return error
+    return 0
+}
+
+# Attempt to create a pid file for the process
+# This function assumes the process is already up and running and can
+#    respond to a getpid call.  It also assumes that two processes
+#    with the same name will not be run on the machine
+# Do not print any error messages as failure to create a pid file because
+#    pid files are strictly optional
+# This function should really only be called in a "start" function
+#    you have been warned
+create_pid_file() {
+    # Validate a pid directory even exists
+    if [ -w $PID_DIR ]; then
+        # Grab the proper pid from getpid
+        if [ ! getpid ]; then
+            return 1
+        else
+            # Remove pid file if it already exists since we do not
+            # plan for multiple identical runners on a single machine
+            rm -f $PID_FILE
+            echo $PID > $PID_FILE
+            return 0
+        fi
+    else
+        return 1
+    fi
+}
+
 # Function to su into correct user
 check_user() {
     # Validate that the user running the script is the owner of the
     # RUN_DIR.
-
-    if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
+    if ([ "$RUNNER_USER" ] && [ -w $RUN_DIR ]); then
         type sudo > /dev/null 2>&1
         if [ "$?" -ne 0 ]; then
             echoerr "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -100,16 +100,21 @@ ping_node() {
 # read/write/delete .pid files during startup/shutdown
 create_pid_dir() {
     # Validate RUNNER_USER is set and they have permissions to write to /var/run
-    if ([ "$RUNNER_USER" ] && [ -w $RUN_DIR ]); then
-        if [ ! mkdir -p $PID_DIR]; then
-            return 1
-        else
-            # Change permissions on $PID_DIR
-            if [ ! chown $RUNNER_USER $PID_DIR]; then
+    if [ "$RUNNER_USER" ]; then
+        if [ -w $RUN_DIR ]; then
+            if [ ! mkdir -p $PID_DIR]; then
                 return 1
             else
-                return 0
+                # Change permissions on $PID_DIR
+                if [ ! chown $RUNNER_USER $PID_DIR]; then
+                    return 1
+                else
+                    return 0
+                fi
             fi
+        else
+            # If we don't have permissions, fail
+            return 1
         fi
     fi
 

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -11,7 +11,8 @@
 # Create PID directory if it does not exist before dropping permissiongs
 # to the runner user
 if [ ! create_pid_dir ]; then
-    echoerr "Warning: Unable to create $PID_DIR, .pid files will not be used"
+    echoerr "Unable to create $PID_DIR, permission denied, run script as root"
+    exit 1
 fi
 
 # Make sure the user running this script is the owner and/or su to that user

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -8,20 +8,6 @@
 . "{{runner_base_dir}}/lib/env.sh"
 
 
-# Create PID directory if it does not exist before dropping permissiongs
-# to the runner user
-if [ ! create_pid_dir ]; then
-    echoerr "Unable to create $PID_DIR, permission denied, run script as root"
-    exit 1
-fi
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-ES=$?
-if [ "$ES" -ne 0 ]; then
-    exit $ES
-fi
-
 # Keep track of where script was invoked
 ORIGINAL_DIR=$(pwd)
 
@@ -37,10 +23,38 @@ usage() {
     echo "                    getpid | top [-interval N] [-sort reductions|memory|msg_q] [-lines N] }"
 }
 
+# All commands must either call boostrap or boostrapd
+# Call boostrap for non-daemon commands like ping or chkconfig
+# Call boostrapd for daemon commands like start/stop/console
+boostrap() {
+    # Make sure the user running this script is the owner and/or su to that user
+    check_user $@
+    ES=$?
+    if [ "$ES" -ne 0 ]; then
+        exit $ES
+    fi
+}
+
+boostrapd() {
+    # Create PID directory if it does not exist before dropping permissiongs
+    # to the runner user
+    create_pid_dir
+    ES=$?
+    if [ "$ES" -ne 0 ]; then
+        echoerr "Unable to access $PID_DIR, permission denied, run script as root"
+        exit 1
+    fi
+
+    # Now call boostrap to drop to $RUNNER_USER
+    boostrap
+}
 
 # Check the first argument for instructions
 case "$1" in
     start)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         # Make sure there is not already a node running
         node_down_check
 
@@ -100,6 +114,9 @@ case "$1" in
         ;;
 
     stop)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         get_pid
         ES=$?
         if [ "$ES" -ne 0 ] || [ -z $PID ]; then
@@ -122,6 +139,9 @@ case "$1" in
         ;;
 
     restart)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         ## Restart the VM without exiting the process
         $NODETOOL restart
         ES=$?
@@ -131,6 +151,9 @@ case "$1" in
         ;;
 
     reboot)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         ## Restart the VM completely (uses heart to restart it)
         $NODETOOL reboot
         ES=$?
@@ -140,6 +163,9 @@ case "$1" in
         ;;
 
     ping)
+        # Boostrap command (simply drop to $RUNNER_USER)
+        boostrap
+
         ## See if the VM is alive
         ping_node
         ES=$?
@@ -149,6 +175,9 @@ case "$1" in
         ;;
 
     attach-direct)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         # Allow attaching to a node without pinging it
         if [ "$2" = "-f" ]; then
           echo "Forcing connection..."
@@ -162,6 +191,9 @@ case "$1" in
         ;;
 
     attach)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         # Make sure a node is running
         node_up_check
 
@@ -171,6 +203,9 @@ case "$1" in
         ;;
 
     console)
+        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
+        boostrapd
+
         RES=`ping_node`
         if [ "$?" -eq 0 ]; then
             echo "Node is already running - use '$SCRIPT attach' instead"
@@ -214,7 +249,11 @@ case "$1" in
         # Start the VM
         exec $CMD
         ;;
+
     top)
+        # Bootstrap command (simply drop to $RUNNER_USER)
+        bootstrap
+
         # Make sure the local node IS running
         node_up_check
 
@@ -228,20 +267,34 @@ case "$1" in
             -node $NODE_NAME \
             $* -tracing off
         ;;
+
     ertspath)
         echo $ERTS_PATH
         ;;
+
     chkconfig)
+        # Bootstrap command (simply drop to $RUNNER_USER)
+        bootstrap
+
         check_config
         ;;
+
     escript)
+        # Bootstrap command (simply drop to $RUNNER_USER)
+        bootstrap
+
         shift
         $ERTS_PATH/escript "$@"
         ;;
+
     version)
         echo $APP_VERSION
         ;;
+
     getpid)
+        # Bootstrap command (simply drop to $RUNNER_USER)
+        bootstrap
+
         # Get the PID from nodetool
         get_pid
         ES=$?

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -7,6 +7,13 @@
 # Pull environment for this install
 . "{{runner_base_dir}}/lib/env.sh"
 
+
+# Create PID directory if it does not exist before dropping permissiongs
+# to the runner user
+if [ ! create_pid_dir ]; then
+    echoerr "Warning: Unable to create $PID_DIR, .pid files will not be used"
+fi
+
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@
 ES=$?
@@ -75,6 +82,8 @@ case "$1" in
                 fi
                 PROCESS=`$NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
                 if [ "$PROCESS" != "undefined" ]; then
+                    # Attempt to create a .pid file for the process
+                    create_pid_file
                     exit 0
                 fi
             done
@@ -84,6 +93,9 @@ case "$1" in
             echo "WAIT_FOR_ERLANG to the number of seconds to wait."
             exit 1
         fi
+
+        # Attempt to create .pid file
+        create_pid_file
         ;;
 
     stop)
@@ -103,6 +115,9 @@ case "$1" in
         do
             sleep 1
         done
+
+        # remove pid file
+        rm -f $PID_FILE
         ;;
 
     restart)

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -23,10 +23,10 @@ usage() {
     echo "                    getpid | top [-interval N] [-sort reductions|memory|msg_q] [-lines N] }"
 }
 
-# All commands must either call boostrap or boostrapd
-# Call boostrap for non-daemon commands like ping or chkconfig
-# Call boostrapd for daemon commands like start/stop/console
-boostrap() {
+# All commands must either call bootstrap or bootstrapd
+# Call bootstrap for non-daemon commands like ping or chkconfig
+# Call bootstrapd for daemon commands like start/stop/console
+bootstrap() {
     # Make sure the user running this script is the owner and/or su to that user
     check_user $@
     ES=$?
@@ -35,7 +35,7 @@ boostrap() {
     fi
 }
 
-boostrapd() {
+bootstrapd() {
     # Create PID directory if it does not exist before dropping permissiongs
     # to the runner user
     create_pid_dir
@@ -45,15 +45,15 @@ boostrapd() {
         exit 1
     fi
 
-    # Now call boostrap to drop to $RUNNER_USER
-    boostrap
+    # Now call bootstrap to drop to $RUNNER_USER
+    bootstrap $@
 }
 
 # Check the first argument for instructions
 case "$1" in
     start)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         # Make sure there is not already a node running
         node_down_check
@@ -114,8 +114,8 @@ case "$1" in
         ;;
 
     stop)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         get_pid
         ES=$?
@@ -139,8 +139,8 @@ case "$1" in
         ;;
 
     restart)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         ## Restart the VM without exiting the process
         $NODETOOL restart
@@ -151,8 +151,8 @@ case "$1" in
         ;;
 
     reboot)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         ## Restart the VM completely (uses heart to restart it)
         $NODETOOL reboot
@@ -163,8 +163,8 @@ case "$1" in
         ;;
 
     ping)
-        # Boostrap command (simply drop to $RUNNER_USER)
-        boostrap
+        # Bootstrap command (simply drop to $RUNNER_USER)
+        bootstrap $@
 
         ## See if the VM is alive
         ping_node
@@ -175,8 +175,8 @@ case "$1" in
         ;;
 
     attach-direct)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         # Allow attaching to a node without pinging it
         if [ "$2" = "-f" ]; then
@@ -191,8 +191,8 @@ case "$1" in
         ;;
 
     attach)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         # Make sure a node is running
         node_up_check
@@ -203,8 +203,8 @@ case "$1" in
         ;;
 
     console)
-        # Boostrap daemon command (check perms & drop to $RUNNER_USER)
-        boostrapd
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
 
         RES=`ping_node`
         if [ "$?" -eq 0 ]; then
@@ -252,7 +252,7 @@ case "$1" in
 
     top)
         # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap
+        bootstrap $@
 
         # Make sure the local node IS running
         node_up_check
@@ -274,14 +274,14 @@ case "$1" in
 
     chkconfig)
         # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap
+        bootstrap $@
 
         check_config
         ;;
 
     escript)
         # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap
+        bootstrap $@
 
         shift
         $ERTS_PATH/escript "$@"
@@ -293,7 +293,7 @@ case "$1" in
 
     getpid)
         # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap
+        bootstrap $@
 
         # Get the PID from nodetool
         get_pid


### PR DESCRIPTION
To properly support OS startup / shutdown scripts (sysvinit for example) we would like to enable the creation/deletion of .pid files.  The issue with .pid creation in the init files (as is standard) is the system can get into a bad state if for example init is used for runner startup, but then ./runner stop is used for shutdown.  

This PR attempts to address that by creating the .pid files in the runner script itself.  No attempt was made to make this setup work for devrel (multi-node, single machine) builds because those are typically run as non-root.
