### PR TITLE
Return nonzero exit codes on init function failure

### DIFF
--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -84,7 +84,9 @@ case "$1" in
         do_start
         case "$?" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            2) [ "$VERBOSE" != no ] && log_end_msg 1
+                exit 1
+                ;;
         esac
         ;;
     stop)
@@ -92,7 +94,9 @@ case "$1" in
         do_stop
         case "$?" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-            2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            2) [ "$VERBOSE" != no ] && log_end_msg 1
+                exit 1
+                ;;
         esac
         ;;
     ping)
@@ -102,7 +106,9 @@ case "$1" in
     reload|force-reload)
         log_daemon_msg "Reloading $DESC" "$NAME"
         do_reload
-        log_end_msg $?
+        ES=$?
+        log_end_msg $ES
+        exit $ES
         ;;
     restart)
         log_daemon_msg "Restarting $DESC" "$NAME"
@@ -112,13 +118,13 @@ case "$1" in
                 do_start
                 case "$?" in
                     0) log_end_msg 0 ;;
-                    1) log_end_msg 1 ;; # Old process is still running
-                    *) log_end_msg 1 ;; # Failed to start
+                    1) log_end_msg 1 && exit 1 ;; # Old process is still running
+                    *) log_end_msg 1 && exit 1 ;; # Failed to start
                 esac
                 ;;
             *)
                 # Failed to stop
-                log_end_msg 1
+                log_end_msg 1 && exit 1
                 ;;
         esac
         ;;

--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -81,6 +81,7 @@ do_status() {
 case "$1" in
     start)
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        $DAEMON ping 2>&1>/dev/null && echo $"$NAME is already running" && exit 0
         do_start
         case "$?" in
             0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;


### PR DESCRIPTION
Addresses #40

The Debian policy is vague on "proper" exit codes, many times
going against the LSB.  See http://wiki.debian.org/LSBInitScripts
for reference.  This commit goes with the LSB to at least return
nonzero exit codes on start/stop/reload/restart functions.

Here is the behavior in testing

```
➜  init.d  sudo ./riak start
!!!!
!!!! WARNING: ulimit -n is 1024; 4096 is the recommended minimum.
!!!!
➜  init.d  echo $?
0
➜  init.d  sudo ./riak ping
pong
➜  init.d  echo $?
0
➜  init.d  sudo ./riak stop
ok
➜  init.d  echo $?
0
➜  init.d  sudo ./riak ping
Node 'riak@127.0.0.1' not responding to pings.
➜  init.d  echo $?
1
➜  init.d  sudo emacs /etc/riak/app.config # edit config here to fail
➜  init.d  head -5 /etc/riak/app.config
%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
%% ex: ft=erlang ts=4 sw=4 et
[ parse,error,in,the,house]]]]]
 %% Riak Client APIs config
 {riak_api, [
➜  init.d  sudo ./riak ping
Node 'riak@127.0.0.1' not responding to pings.
➜  init.d  sudo ./riak start
Error on line 3: syntax error before: ']'
Error reading /etc/riak/app.config
➜  init.d  echo $?
1
➜  init.d  sudo ./riak stop
Node 'riak@127.0.0.1' not responding to pings.
Node is not running!
➜  init.d  echo $?
0
➜  init.d  sudo ./riak ping
Node 'riak@127.0.0.1' not responding to pings.
➜  init.d  echo $?
1
➜  init.d  sudo ./riak restart
 * Restarting Riak is a distributed data store riak                                                              Node 'riak@127.0.0.1' not responding to pings.
Node is not running!
Error on line 3: syntax error before: ']'
Error reading /etc/riak/app.config
➜  init.d  echo $?
0
```

The final return code of "0" is correct on a restart when the node isn't running to begin with.
