### PR TITLE
Fix %files section to not claim ownership of bindir and mandir

### DIFF
--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -126,12 +126,12 @@ chmod 0755 %{_libdir}/{{package_install_name}}/lib/env.sh
 %{_libdir}/*
 %dir %{_sysconfdir}/{{package_install_name}}
 %config(noreplace) %{_sysconfdir}/{{package_install_name}}/*
-%{_{{bin_or_sbin}}dir}
+%{_{{bin_or_sbin}}dir}/*
 %{_localstatedir}/lib/{{package_install_name}}
 %{_localstatedir}/log/{{package_install_name}}
 %{_localstatedir}/run/{{package_install_name}}
 %{_sysconfdir}/init.d/{{package_install_name}}
-%{_mandir}/man1
+%{_mandir}/man1/*
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
Addresses: #50 basho/riak_cs#554

The %files section had to general a case for both (s)bindir and mandir, specifying the actual directory rather than the contents of the directory.  This change simply changes those
two lines to be the `<dir>/*` style as recommended in the [fedora package maintainers documentation](http://fedoraproject.org/wiki/How_to_create_an_RPM_package#.25files_section)
