### PR TITLE
Add support for SmartOS 13.1

### DIFF
--- a/priv/templates/smartos/+INSTALL
+++ b/priv/templates/smartos/+INSTALL
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Variable that will get replaced by the Makefile dirs_create target
+CREATE_DIRS="%DIRS_CREATE%"
+
 if [ "$2" = "PRE-INSTALL" ]; then
     if ! getent group "{{package_install_group}}" 2>/dev/null 1>&2; then
         groupadd {{package_install_group}}
@@ -10,13 +13,17 @@ if [ "$2" = "PRE-INSTALL" ]; then
     fi
 
     # Create var directories outside of +CONTENTS
-    mkdir -p {{platform_data_dir}}
-    chown -R {{package_install_user}}:{{package_install_group}} {{platform_data_dir}}
-    chmod 700 {{platform_data_dir}}
-    mkdir -p {{platform_log_dir}}
-    chmod 700 {{platform_log_dir}}
-    chown -R {{package_install_user}}:{{package_install_group}} {{platform_log_dir}}
-
+    # Read directories from the CREATE_DIRS variable
+    for i in $CREATE_DIRS; do
+        if [ -d $i ]; then
+            echo "Skipping directory creation of $i, directory already exists"
+        else
+            echo "Creating directory $i owned by {{package_install_user}}"
+            mkdir -p $i
+            chown -R {{package_install_user}}:{{package_install_group}} $i
+            chmod 700 $i
+        fi
+    done
 
     # Backup config files if they already exist
     if [ -f {{platform_etc_dir}}/vm.args ]; then
@@ -61,5 +68,3 @@ if [ "$2" = "POST-INSTALL" ]; then
     chmod 755 /opt/local/share/smf/{{package_install_name}}-epmd/{{package_install_name}}-epmd
     svccfg import /opt/local/share/smf/{{package_install_name}}/manifest.xml
 fi
-
-exit 0

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -4,28 +4,68 @@ BUILDDIR        = $(shell pwd)
 PACKAGE_NAME_CLEAN = $(shell echo "{{package_name}}" | sed -e 's/-/_/g')
 BUILD_STAGE_DIR = $(BUILDDIR)/$(PACKAGE_NAME_CLEAN)
 
+## Version Information
+## ## pkgsrc version mapping to SmartOS version
+##   SmartOS                 pkgsrc
+##   1.6                     2011Q4
+##   1.8                     2012Q2
+##   13.1                    2013Q1
+## ## Erlang Deps by version
+##   SmartOS      openssl        ncurses
+##   1.6          0.9.8knb1      5.4nb1
+##   1.8          0.9.8knb1      5.4nb1
+##  13.1          1.0.1c         5.4nb1
+## ## Additional Deps for runner
+## sudo (same for all versions)
+##
+## ## SMF Manifest Mapping
+##   SmartOS     Manifest File
+##   1.6         manifest.xml
+##   1.8         manifest18.xml
+##  13.1         manifest18.xml
 
-# SmartOS changed pkgsrc versions which majorly changed
-# the layout of the filesystem.  SmartOS 1.6 uses a
-# different SMF manifest file than newer versions
-SMF_MANIFEST = $(shell head -1 /etc/pkgsrc_version | \
-                 grep -c 2011Q4 2> /dev/null | awk \
-                 '{if ($$1 == "1") {print "manifest.xml"} else {print "manifest18.xml"}}')
+PKGSRC_VERSION = $(shell head -1 /etc/pkgsrc_version 2>/dev/null | cut -d' ' -f2)
+
+ifeq ($(PKGSRC_VERSION),2011Q4)  # SmartOS 1.6
+NCURSES_DEP = ncurses-5*
+OPENSSL_DEP = openssl-0.9.8*
+GCC_DEP     = gcc-runtime-4.6.2
+SMF_MANIFEST = manifest.xml
+endif
+ifeq ($(PKGSRC_VERSION),2012Q2)  # SmartOS 1.8
+NCURSES_DEP = ncurses-5*
+OPENSSL_DEP = openssl-0.9.8*
+GCC_DEP     = gcc47-runtime>=4.7.0
+SMF_MANIFEST = manifest18.xml
+endif
+ifeq ($(PKGSRC_VERSION),2013Q1)  # SmartOS 13.1
+NCURSES_DEP = ncurses-5*
+OPENSSL_DEP = openssl-1.0.1*
+GCC_DEP     = gcc47-libs>=4.7.0
+SMF_MANIFEST = manifest131.xml
+endif
+
 
 # Where we install things (based on vars.config)
 # /opt/local based dirs
+# /var based dirs are handled in the +INSTALL file and dirs_file target
 PMAN_DIR         := $(BUILD_STAGE_DIR)/man
 PBIN_DIR         := $(BUILD_STAGE_DIR)/{{bin_or_sbin}}
 PETC_DIR         := $(BUILD_STAGE_DIR)/etc/{{package_install_name}}
 PLIB_DIR         := $(BUILD_STAGE_DIR)/lib/{{package_install_name}}
 PSMF_DIR         := $(BUILD_STAGE_DIR)/share/smf/{{package_install_name}}
 ESMF_DIR         := $(BUILD_STAGE_DIR)/share/smf/{{package_install_name}}-epmd
+PDATA_DIR        := $(BUILD_STAGE_DIR)/{{platform_data_dir}}
+
+# For scanning later, grab the first dirname
+# '/var/db/server' becomes 'var'
+PDATA_ROOT_DIR   = $(shell echo "{{platform_data_dir}}" | cut -d'/' -f 2)
+
+
 
 # Recursive assignment of ERTS version
 # We will know this after building the rel
 ERTS_PATH        = $(shell ls $(BUILDDIR)/rel/{{package_install_name}} | egrep -o "erts-.*")
-
-# /var based dirs are handled in the +INSTALL file
 
 TARNAME := $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
 PKGNAME := $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
@@ -36,7 +76,7 @@ PKGNAME := $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
 # particular order to not anger pkg_add.
 # This is done by piping the file listings into tar
 #  in the same manner we did with the +CONTENTS file
-build: packing_list_files
+build: packing_list_files dirs_file
 	@echo "Building package $(PKGNAME)"
 	mkdir -p packages
 	cd $(BUILD_STAGE_DIR) && \
@@ -58,6 +98,7 @@ build: packing_list_files
 		shasum -a 256 $${tarfile} > $${tarfile}.sha \
 	; done
 
+
 # Where most of the magic (horror?) happens
 # Create a packing list according to pkg_create(1)
 # Write initial settings to a local plist then copy
@@ -68,19 +109,23 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	echo "@name $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)" >> plist
 	echo "@pkgcfl $(PACKAGE_NAME_CLEAN)-*" >> plist
 	echo "@pkgdep sudo-[0-9]*" >> plist
-	echo "@pkgdep openssl-0.9.8*" >> plist
+	echo "@pkgdep $(OPENSSL_DEP)" >> plist
+	echo "@pkgdep $(NCURSES_DEP)" >> plist
+	echo "@pkgdep $(GCC_DEP)" >> plist
 
 	@echo "Copying staging package listing to +CONTENTS"
 	mv plist $(BUILD_STAGE_DIR)/+CONTENTS
 
 	@echo "Packaging /opt/local files"
 	cd $(BUILD_STAGE_DIR) && \
+	   echo "@comment Packing manpage files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group root" >> +CONTENTS && \
 	   find man -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
+	   echo "@comment Packing /opt/local/etc files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group {{package_install_user}}" >> +CONTENTS && \
@@ -90,17 +135,22 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@exec chmod -R g+r+X {{platform_etc_dir}}" >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
+	   echo "@comment Packing lib files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
 	   echo "@group {{package_install_group}}" >> +CONTENTS
+
 	cd $(BUILD_STAGE_DIR) && \
 	   find lib -type f >> +CONTENTS && \
 	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_base_dir}}" >> +CONTENTS
+
 	cd $(BUILD_STAGE_DIR) && \
+	   echo "@comment Packing /usr/local {{bin_or_sbin}} files" >> +CONTENTS && \
 	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
 	   echo "@group {{package_install_group}}" >> +CONTENTS && \
 	   echo "@mode 0755" >> +CONTENTS && \
 	   find {{bin_or_sbin}} -type f >> +CONTENTS
+
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
 	   echo "@group {{package_install_group}}" >> +CONTENTS && \
@@ -110,11 +160,33 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@display +DISPLAY" >> +CONTENTS
 
 
+# Creates a variable to be read by the +INSTALL script to
+# create directories not supported by the +CONTENTS file
+# such as log and data directories.
+# platform_log_dir and platform_data_dir are always added
+# This is black magic appending the directories to the
+# to a variable inside of the makefile target
+# and then using sed to insert that list into
+# the +INSTALL script.
+# I feel dirty now.
+dirs_file: $(BUILD_STAGE_DIR)
+	@echo "Adding data and log directories to directory list"
+	$(eval DIRS_INSTALL = {{platform_data_dir}})
+	$(eval DIRS_INSTALL += {{platform_log_dir}})
+	@echo "Scanning var directory for any additional install paths"
+	$(eval DIRS_INSTALL += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
+	cd $(BUILD_STAGE_DIR) && \
+	   cp +INSTALL +INSTALL.tmp && \
+	   sed -e 's|%DIRS_CREATE%|${DIRS_INSTALL}|' < \
+	       +INSTALL.tmp > +INSTALL && \
+	   rm +INSTALL.tmp
+
+
 # These are static files that should not have to change often
 templates: $(BUILD_STAGE_DIR)
 	@echo "Copying metadata files to package"
 	cp $(PKGERDIR)/+DESC $(PKGERDIR)/+COMMENT $(PKGERDIR)/+DEINSTALL \
-           $(PKGERDIR)/+INSTALL $(PKGERDIR)/+BUILD_INFO \
+	   $(PKGERDIR)/+INSTALL $(PKGERDIR)/+BUILD_INFO \
 	   $(PKGERDIR)/+DISPLAY $(BUILD_STAGE_DIR)
 	mkdir -p $(PSMF_DIR)
 	cp $(PKGERDIR)/$(SMF_MANIFEST) $(PSMF_DIR)/manifest.xml
@@ -131,6 +203,8 @@ templates: $(BUILD_STAGE_DIR)
 # The data and log directories need to go into /var, but the
 # smartos pkg_add doesn't allow this to be in the +CONTENTS
 # file so the directories are created in the +INSTALL script
+# We copy the data and log directories if they exist to make
+# scanning them easier later
 $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
@@ -143,19 +217,30 @@ $(BUILD_STAGE_DIR): buildrel
 	cp -R $(BUILDDIR)/rel/{{package_install_name}}/lib $(PLIB_DIR)
 	cp -R $(BUILDDIR)/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
 	cp -R $(BUILDDIR)/rel/{{package_install_name}}/releases $(PLIB_DIR)
-	echo "Copying man pages to staging directory"
+	@echo "Copying man pages to staging directory"
 	mkdir -p $(PMAN_DIR)
 	if [ -d $(BUILDDIR)/doc/man/man1 ]; then \
-		cp -R $(BUILDDIR)/doc/man/man1 $(PMAN_DIR); fi
+	    cp -R $(BUILDDIR)/doc/man/man1 $(PMAN_DIR); fi
+	@echo "Copying data and log directories to staging directory"
+	if [ -d $(BUILDDIR)/rel/{{package_install_name}}/data ]; then \
+	   mkdir -p $(PDATA_DIR) && \
+	   cp -R $(BUILDDIR)/rel/{{package_install_name}}/data/* $(PDATA_DIR); fi
 
 
+# If we can read the PKGSRC_VERSION we should fail
+# If NCURSES_DEP wasn't set, we know it was an unknown PKGSRC version
+smartos_check:
+	@echo "Checking SmartOS Version"
+	$(if $(PKGSRC_VERSION),,$(error "Cannot find pkgsrc version from /etc/pkgsrc_version, cannot continue"))
+	$(if $(NCURSES_DEP),,$(error "Unsupported SmartOS version, please add to github.com/basho/node_package"))
+	@echo "Building for pkgsrc version $(PKGSRC_VERSION)"
 
 # Build the release we need to package
 #  * Patch rel/files/riak with our version
 #  * Ensure all binaries are executable
 #  * copy the vars.config over for build config
 # TODO, solve the .patch issue we have in riak
-buildrel: $(BUILDDIR)
+buildrel: $(BUILDDIR) smartos_check
 	OVERLAY_VARS="overlay_vars=../smartos/vars.config" $(MAKE) deps rel
 	chmod 0755 $(BUILDDIR)/rel/{{package_install_name}}/bin/* $(BUILDDIR)/rel/{{package_install_name}}/erts-*/bin/*
 

--- a/priv/templates/smartos/manifest131.xml
+++ b/priv/templates/smartos/manifest131.xml
@@ -18,9 +18,9 @@
       <method_environment>
         <envvar name="HOME" value="{{platform_base_dir}}" />
         <envvar name="LOGNAME" value="{{package_install_user}}" />
-        <envvar name="PATH" value="/usr/bin:/bin:/opt/local/bin:/opt/local/sbin" />
+        <envvar name="PATH" value="/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin" />
         <envvar name="LD_PRELOAD_32" value="/lib/libumem.so.1" />
-        <envvar name="LD_PRELOAD_64" value="/lib/64/libumem.so.1:/opt/local/lib/amd64/libgcc_s.so.1:/opt/local/lib/amd64/libstdc++.so.6"/>
+        <envvar name="LD_PRELOAD_64" value="/lib/amd64/libumem.so.1:/opt/local/gcc47/lib/amd64/libgcc_s.so.1"/>
         <envvar name="UMEM_OPTIONS" value="allocator=best" />
       </method_environment>
     </method_context>

--- a/priv/templates/smartos/smartos.template
+++ b/priv/templates/smartos/smartos.template
@@ -29,4 +29,5 @@
 {template, "epmd-manifest.xml", "epmd-manifest.xml"}.
 {template, "manifest.xml", "manifest.xml"}.
 {template, "manifest18.xml", "manifest18.xml"}.
+{template, "manifest131.xml", "manifest131.xml"}.
 {template, "epmd", "epmd"}.


### PR DESCRIPTION
This is a major cleanup of the Makefile to determine what
dependencies are needed as well as determining the
SMF manifest file to use.

In addition, directories that are found in the rel/<appname>/data
directory are now automatically installed on SmartOS's
platform_data_dir.  This fixes previous bugs where Riak's
SNMP would crash when it couldn't access its database
directory.
