### PR TITLE
remove contract specification from SMF manifests (solaris)

### DIFF
--- a/priv/templates/smartos/manifest.xml
+++ b/priv/templates/smartos/manifest.xml
@@ -27,10 +27,6 @@
     <exec_method type="method" name="start" exec="{{platform_bin_dir}}/{{package_install_name}} start" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec="{{platform_bin_dir}}/{{package_install_name}} stop" timeout_seconds="60" />
     <exec_method type="method" name="restart" exec="{{platform_bin_dir}}/{{package_install_name}} restart" timeout_seconds="60" />
-    <property_group name="startd" type="framework">
-      <propval name="duration" type="astring" value="contract" />
-      <propval name="ignore_error" type="astring" value="core,signal" />
-    </property_group>
     <stability value="Stable" />
     <template>
       <common_name>

--- a/priv/templates/smartos/manifest131.xml
+++ b/priv/templates/smartos/manifest131.xml
@@ -27,10 +27,6 @@
     <exec_method type="method" name="start" exec="{{platform_bin_dir}}/{{package_install_name}} start" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec="{{platform_bin_dir}}/{{package_install_name}} stop" timeout_seconds="60" />
     <exec_method type="method" name="restart" exec="{{platform_bin_dir}}/{{package_install_name}} restart" timeout_seconds="60" />
-    <property_group name="startd" type="framework">
-      <propval name="duration" type="astring" value="contract" />
-      <propval name="ignore_error" type="astring" value="core,signal" />
-    </property_group>
     <stability value="Stable" />
     <template>
       <common_name>

--- a/priv/templates/smartos/manifest18.xml
+++ b/priv/templates/smartos/manifest18.xml
@@ -27,10 +27,6 @@
     <exec_method type="method" name="start" exec="{{platform_bin_dir}}/{{package_install_name}} start" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec="{{platform_bin_dir}}/{{package_install_name}} stop" timeout_seconds="60" />
     <exec_method type="method" name="restart" exec="{{platform_bin_dir}}/{{package_install_name}} restart" timeout_seconds="60" />
-    <property_group name="startd" type="framework">
-      <propval name="duration" type="astring" value="contract" />
-      <propval name="ignore_error" type="astring" value="core,signal" />
-    </property_group>
     <stability value="Stable" />
     <template>
       <common_name>


### PR DESCRIPTION
SMF uses the property (ignore_error), that this commit removes to determine how
the service should be affected under failure conditions.
This commit makes it so SMF reverts to its default behavior
to consider a service as "failed" if _any_ of the processes
that make up the service dump core, or if _any_ of the processes
receive a fatal signal originating outside of the service (ie.
if a processes raises its own signal or sends a signal to another
process within the same service that doesn't cause a
core dump, SMF ignores it)

It is in my experience running Riak in production at Voxer, if
a core dump is generated, the service will think riak is alive and
healthy, even though it is completely unresponsive.

This change makes it so any fatal signal to any of the processes
controlled by SMF for riak will trigger SMF to restart the service,
as well as if any of the processes dump core
