### PR TITLE
Exit with escript exit codes instead of always exiting with 0.

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -289,7 +289,10 @@ case "$1" in
 
         shift
         $ERTS_PATH/escript "$@"
-        exit $?
+        ES=$?
+        if [ "$ES" -ne 0 ]; then
+            exit $ES
+        fi
         ;;
 
     version)

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -289,6 +289,7 @@ case "$1" in
 
         shift
         $ERTS_PATH/escript "$@"
+        exit $?
         ;;
 
     version)


### PR DESCRIPTION
Allows escript to return non-zero exit codes for error handling, etc. Alternatively, instead of exiting from within the case statement, we could use a return variable that could be set from any statement, and use that at the end instead of 'exit 0'.
