### PR TITLE
Fix issue with dpkg purges failing in the postrm script

### DIFF
--- a/priv/templates/deb/postrm
+++ b/priv/templates/deb/postrm
@@ -43,11 +43,11 @@ case "$1" in
         fi
         # Remove User & Group, killing any process owned by them
         if getent passwd {{package_install_user}} >/dev/null; then
-                pkill -u {{package_install_user}}
-                deluser --system {{package_install_user}}
+                pkill -u {{package_install_user}} || true
+                deluser --quiet --system {{package_install_user}}
         fi
         if getent group {{package_install_group}} >/dev/null; then
-                delgroup --system --only-if-empty {{package_install_group}}
+                delgroup --quiet --system --only-if-empty {{package_install_group}} || true
         fi
     ;;
 


### PR DESCRIPTION
The postrm causes a purge to fail to run to completion if either the pkill
command fails to kill any processes or the group deletion fails because the
group is not empty. These are acceptable conditions and should not cause the
purge to fail Change each respective command so that failure does not cause
the postrm script to return an error code and erroneously cause failure of the
purge.
