### PR TITLE
Do not error on post install script if usermod fails

### DIFF
--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -105,7 +105,7 @@ if ! getent group {{package_install_group}} >/dev/null 2>&1; then
 fi
 
 if getent passwd {{package_install_user}} >/dev/null 2>&1; then
-   usermod -d %{_localstatedir}/lib/{{package_install_name}} {{package_install_user}}
+   usermod -d %{_localstatedir}/lib/{{package_install_name}} {{package_install_user}} || true
 else
    useradd -r -g {{package_install_group}} \
            --home %{_localstatedir}/lib/{{package_install_name}} \


### PR DESCRIPTION
The usermod command to change the home directory will fail if the
the user is logged in.  We should not fail on this command
as the user will be logged in during upgrades and multiple
application installs.

Fixes: basho/node_package#64
