### PR TITLE
Apply rpm version information to app_version filed in vars.config

### DIFF
--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -31,6 +31,8 @@ Obsoletes: {{package_name}}
 %define platform_lib_dir %{platform_base_dir}/lib
 %define platform_log_dir %{_localstatedir}/log/{{package_install_name}}
 
+
+# Setup vars.config like other platforms, but do it inside of spec file
 %prep
 %setup -q -n {{package_name}}-%{_revision}
 cat > rpm.vars.config <<EOF
@@ -50,8 +52,8 @@ cat > rpm.vars.config <<EOF
 {runner_patch_dir,  "%{platform_lib_dir}/{{package_patch_dir}}"}.
 {runner_user,       "{{package_install_user}}"}.
 {pipe_dir,          "%{_localstatedir}/run/{{package_install_name}}/"}.
+{app_version,       "%{_revision}"}.
 EOF
-
 
 %build
 OVERLAY_VARS="overlay_vars=../rpm.vars.config" make rel


### PR DESCRIPTION
### Commit info

This applies the _revision field in the RPM spec file to the
app_version template variable.  This fixes the issue where
RPMs would not show information for the `runner version` command
due to the env.sh not having the proper variables filled out.

The PKG_VERSION makefile variable is set to the _revision
variable which now gets added to the vars.config properly.

Fixes: basho/node_package#69
### Testing

Tested on Fedora, I ran a build against this branch.  I echo'd the rpm.vars.config that is generated from the `.spec` file and highlighted the added version information that is now in there.  Installing the package showed `riak version` working properly.

```
[buildbot@build-fedora-17-64 riak]$ find -name rpm.vars.config -exec cat {} \;
% Platform-specific installation paths
{platform_bin_dir,  "/usr/sbin"}.
{platform_data_dir, "/var/lib/riak"}.
{platform_etc_dir,  "/etc/riak"}.
{platform_base_dir, "/usr/lib64/riak"}.
{platform_lib_dir,  "/usr/lib64/riak/lib"}.
{platform_log_dir,  "/var/log/riak"}.

{runner_script_dir, "/usr/sbin"}.
{runner_base_dir,   "/usr/lib64/riak"}.
{runner_etc_dir,    "/etc/riak"}.
{runner_log_dir,    "/var/log/riak"}.
{runner_lib_dir,    "/usr/lib64/riak/lib"}.
{runner_patch_dir,  "/usr/lib64/riak/lib/basho-patches"}.
{runner_user,       "riak"}.
{pipe_dir,          "/var/run/riak/"}.
{app_version,       "1.4.0-b5d61c75"}.                     ## <---- new field added
[buildbot@build-fedora-17-64 packages]$ sudo rpm -i riak-1.4.0.b5d61c75-1.fc17.x86_64.rpm
[buildbot@build-fedora-17-64 packages]$ riak version
1.4.0-b5d61c75
[buildbot@build-fedora-17-64 packages]$ sudo riak start
[buildbot@build-fedora-17-64 packages]$ riak ping
pong
[buildbot@build-fedora-17-64 packages]$ riak-admin test
Successfully completed 1 read/write cycle to 'riak@127.0.0.1'
```
