### PR TITLE
Fixed issues with whitespace for non-cuttlefish configs

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -195,7 +195,7 @@ node_up_check() {
 # Function to check if the config file is valid
 check_config() {
     if [ -z "$CUTTLEFISH" ]; then
-        CONFIG_FILE = $RUNNER_ETC_DIR/app.config
+        CONFIG_FILE="$RUNNER_ETC_DIR/app.config"
     else
         cuttlefish
     fi


### PR DESCRIPTION
This fixes bug with the `CONFIG_FILE` variable, discovered by @beerriot.

To reproduce, use node_package master with riak master. (riak master's node_package dependency is currently tagged at 1.3.3, so you'll have to explicitly checkout node_package master)
