### PR TITLE
FreeBSD: Change package name to .tbz and scan data dirs

### DIFF
--- a/priv/templates/fbsd/+DEINSTALL
+++ b/priv/templates/fbsd/+DEINSTALL
@@ -10,4 +10,10 @@ if pw usershow "${USER}" 2>/dev/null 1>&2; then
         echo "To delete {{package_name}} user permanently, use 'pw userdel ${USER}'"
 fi
 
+echo ""
+echo "To completely clean your system you will need to remove the following directories manually"
+echo "* {{platform_data_dir}}"
+echo "* {{platform_log_dir}}"
+
+
 exit 0

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -8,11 +8,15 @@ PBIN_DIR         = $(BUILD_STAGE_DIR)/{{bin_or_sbin}}
 PETC_DIR         = $(BUILD_STAGE_DIR)/etc/{{package_install_name}}
 PLIB_DIR         = $(BUILD_STAGE_DIR)/lib/{{package_install_name}}
 # /var based dirs
-PDATA_DIR        = $(BUILD_STAGE_DIR)/db/
+PDATA_DIR        = $(BUILD_STAGE_DIR)/{{platform_data_dir}}
 PLOG_DIR         = $(BUILD_STAGE_DIR)/log/{{package_install_name}}
 
+# For scanning later, remove the leading slash
+# '/var/db/server' becomes 'var/db/server'
+PDATA_ROOT_DIR   = $(shell echo "{{platform_data_dir}}" | cut -d'/' -f 2-4)
+
 TARNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
-PKGNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
+PKGNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tbz
 
 build: packing_list_files templates
 	@echo "Building package $(PKGNAME)"
@@ -24,7 +28,7 @@ build: packing_list_files templates
 	find {{bin_or_sbin}} -type f | tar -rf $(TARNAME) -T - && \
 	find lib -type f | tar -rf $(TARNAME) -T - && \
 	find etc -type f | tar -rf $(TARNAME) -T - && \
-	find db -type f | tar -rf $(TARNAME) -T - && \
+	find var -type f | tar -rf $(TARNAME) -T - && \
 	find log -type f | tar -rf $(TARNAME) -T -
 
 	cd $(BUILD_STAGE_DIR) && \
@@ -33,7 +37,7 @@ build: packing_list_files templates
 	mv $(TARNAME).gz ../../packages/$(PKGNAME)
 
 	cd ../packages && \
-		for tarfile in `ls *.tgz`; do \
+		for tarfile in `ls *.tbz`; do \
 		shasum -a 256 $${tarfile} > $${tarfile}.sha \
 	; done
 
@@ -68,6 +72,16 @@ packing_list_files: $(BUILD_STAGE_DIR)
                                      ; fi && \
 		{{/package_commands}} echo -n; fi
 
+	@echo "Scanning data and log directories for empty directories to add"
+	$(eval DIRS_INSTALL = {{platform_log_dir}})
+	$(eval DIRS_INSTALL += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
+	for i in $(DIRS_INSTALL); \
+	    do                          \
+		echo "@exec mkdir -p $$i" >> plist; \
+                echo "@exec chown -R {{package_install_user}}:{{package_install_group}} $$i" >> plist; \
+		echo "@exec chmod 700 $$i" >> plist; \
+	    done
+
 	@echo "Copying staging package listing to +CONTENTS"
 	mv plist $(BUILD_STAGE_DIR)/+CONTENTS
 
@@ -78,18 +92,17 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	   echo "@group {{package_install_group}}" >> +CONTENTS && \
 	   echo "@mode 0755" >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
-	   find {{bin_or_sbin}} -type f >> +CONTENTS && \
-           find {{bin_or_sbin}} -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS
+	   find {{bin_or_sbin}} -type f >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
 	   find lib -type f >> +CONTENTS && \
-	   find lib -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS && \
+	   find lib -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS && \
 	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_base_dir}}" >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group wheel" >> +CONTENTS && \
 	   echo "@mode 0644" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS && \
-	   find etc -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS
+	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS
 
 	@echo "Packaging /var files"
 	cd $(BUILD_STAGE_DIR) && \
@@ -98,15 +111,9 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
 	   echo "@group {{package_install_group}}" >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
-	   find db -type f >> +CONTENTS && \
-           find db -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_data_dir}}" >> +CONTENTS && \
-	   echo "@exec chmod 700 {{platform_data_dir}}" >> +CONTENTS
+	   find var/db -type f >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
-	   find log -type f >> +CONTENTS && \
-           find log -d -type d -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_log_dir}}" >> +CONTENTS && \
-	   echo "@exec chmod 700 {{platform_log_dir}}" >> +CONTENTS
+	   find log -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@owner" >> +CONTENTS && \
@@ -126,8 +133,6 @@ templates: $(BUILD_STAGE_DIR)
 # package structure and move the directories into the right place
 # for the package, see the vars.config file for destination
 # directories
-# The data and log directories are by default empty, so create
-# an empty file in them so the file listing makes the directories
 $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
@@ -141,9 +146,7 @@ $(BUILD_STAGE_DIR): buildrel
 	cp -R rel/{{package_install_name}}/releases $(PLIB_DIR)
 	mkdir -p $(PDATA_DIR)
 	cp -R rel/{{package_install_name}}/data/* $(PDATA_DIR)
-	touch $(PDATA_DIR)/.empty
 	mkdir -p $(PLOG_DIR)
-	touch $(PLOG_DIR)/.empty
 
 
 # Build the release we need to package

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -104,6 +104,8 @@ build: packing_list_files dirs_file
 # Write initial settings to a local plist then copy
 #   to the destination folder where we use 'find'
 #   to populate the files
+# SmartOS doesn't allow packages to modify /var
+#   in the +CONTENTS so that is all done in the +INSTALL instead
 packing_list_files: $(BUILD_STAGE_DIR) templates
 	@echo "Adding to packaging list $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)"
 	echo "@name $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)" >> plist
@@ -164,8 +166,8 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 # create directories not supported by the +CONTENTS file
 # such as log and data directories.
 # platform_log_dir and platform_data_dir are always added
-# This is black magic appending the directories to the
-# to a variable inside of the makefile target
+# This is black magic appending the directories to
+# a variable inside of the makefile target
 # and then using sed to insert that list into
 # the +INSTALL script.
 # I feel dirty now.


### PR DESCRIPTION
- This commit changes the naming of the package. `pkg_add`
  on FreeBSD needs package names to end in .tbz rather than .tgz
- The data and log directories were not scanned for extra
  directories so some default directories would be left out
  of the package install.
- Some directories such as /usr/sbin were included in the
  default @dirrm list, those have been removed

Fixes: #77 #83 

New Install / Test / Uninstall run below:
### Install

```
[buildbot@riak-test-freebsd-9 /tmp]$ sudo pkg_add riak-ee-1.4.1-2cabf831-FreeBSD-amd64.tbz
riak:*:1002:
riak:*:1002:1002::0:0:Riak user:/usr/local/lib/riak:/bin/sh

Thank you for installing riak-ee.

riak-ee has been installed in /usr/local owned by user:group riak:riak

The primary directories are:

{platform_bin_dir, "/usr/local/sbin"}
{platform_data_dir, "/var/db/riak"}
{platform_etc_dir, "/usr/local/etc/riak"}
{platform_lib_dir, "/usr/local/lib/riak/lib"}
{platform_log_dir, "/var/log/riak"}

These can be configured and changed in the /usr/local/etc/riak/app.config.

Add /usr/local/sbin to your path to run riak riak-admin search-cmd riak-repl riak-debug directly.

Man pages are available for riak(1) riak-admin(1) search-cmd(1) riak-repl(1) riak-debug(1)
```
### Test

```
[buildbot@riak-test-freebsd-9 /tmp]$ sudo find /var/db/riak -type d
/var/db/riak
/var/db/riak/snmp
/var/db/riak/snmp/agent
/var/db/riak/snmp/agent/db
/var/db/riak/ring
[buildbot@riak-test-freebsd-9 /tmp]$ sudo riak start
[buildbot@riak-test-freebsd-9 /tmp]$ sudo riak ping
pong
```
### Uninstall

```
[buildbot@riak-test-freebsd-9 /tmp]$ sudo pkg_delete "riak-ee-*"
pkg_delete: file '/usr/local/lib/riak/lib/mnesia-4.7/include' doesn't exist
pkg_delete: unable to completely remove directory '/usr/local/lib/riak/lib/mnesia-4.7/include'
pkg_delete: file '/usr/local/lib/riak/erts-5.9.1/doc' doesn't exist
pkg_delete: unable to completely remove directory '/usr/local/lib/riak/erts-5.9.1/doc'
pkg_delete: file '/usr/local/lib/riak/erts-5.9.1/man' doesn't exist
pkg_delete: unable to completely remove directory '/usr/local/lib/riak/erts-5.9.1/man'
pkg_delete: unable to completely remove directory '/usr/local/lib/riak'
pkg_delete: couldn't entirely delete package `riak-ee-1.4.1-2cabf831'
(perhaps the packing list is incorrectly specified?)
To delete riak-ee user permanently, use 'pw userdel riak'

To completely clean your system you will need to remove the following directories manually
* /var/db/riak
* /var/log/riak


[buildbot@riak-test-freebsd-9 /tmp]$ sudo find /var/db/riak -type d -maxdepth 1
/var/db/riak
/var/db/riak/snmp
/var/db/riak/ring
/var/db/riak/kv_vnode
/var/db/riak/bitcask
/var/db/riak/anti_entropy
/var/db/riak/riak_repl
[buildbot@riak-test-freebsd-9 /tmp]$ sudo ls -l /var/log/riak
total 56
-rw-r--r--  1 riak  riak  11547 Aug 21 20:33 console.log
-rw-r--r--  1 riak  riak    450 Aug 21 20:33 crash.log
-rw-r--r--  1 riak  riak    564 Aug 21 20:32 erlang.log.1
-rw-r--r--  1 riak  riak    334 Aug 21 20:33 error.log
-rw-r--r--  1 riak  riak    261 Aug 21 20:32 run_erl.log
```
