### PR TITLE
Fix return code of service stop in the RPM init script

### DIFF
--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -69,11 +69,11 @@ stop() {
     if [ $RETVAL -eq 1 ]; then
         rm -f $lockfile $pidfile
         success
+        echo && return 0
     else
         failure $"$NAME stop"
+        echo && return 1
     fi
-    echo
-    return $RETVAL
 }
 
 hardstop() {
@@ -90,11 +90,11 @@ hardstop() {
     if [ $RETVAL -eq 1 ]; then
         rm -f $lockfile $pidfile
         success
+        echo && return 0
     else
         failure $"$NAME hardstop"
+        echo && return 1
     fi
-    echo
-    return $RETVAL
 }
 
 # See how we were called.


### PR DESCRIPTION
The return code resulting from service stop was inverted from what it
should have been, confusing tools that expect 0 to be success and 1 to
be failure.
