### PR TITLE
Small FreeBSD package fix.

### DIFF
--- a/priv/templates/fbsd/+DISPLAY
+++ b/priv/templates/fbsd/+DISPLAY
@@ -10,7 +10,7 @@ The primary directories are:
     {platform_lib_dir, "{{platform_lib_dir}}"}
     {platform_log_dir, "{{platform_log_dir}}"}
 
-These can be configured and changed in the {{platform_etc_dir}}/app.config.
+These can be configured and changed in the {{platform_etc_dir}}/riak.conf file.
 
 Add {{platform_bin_dir}} to your path to run {{#package_commands}}{{name}} {{/package_commands}} directly.
 

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -101,6 +101,8 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	   echo "@owner root" >> +CONTENTS && \
 	   echo "@group wheel" >> +CONTENTS && \
 	   echo "@mode 0644" >> +CONTENTS && \
+	   echo "@exec mkdir -p {{platform_etc_dir}}/generated" && \
+	   echo "@exec chown {{package_install_user}}:{{package_install_group}} {{platform_etc_dir}}/generated" && \
 	   find etc -type f >> +CONTENTS && \
 	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS
 


### PR DESCRIPTION
Modify FreeBSD message to alert user to riak.conf file instead of app.config file.

Modify package to create /usr/local/etc/riak/generated directory with
correct permissions so riak/cuttlefish can write generated app.config
and vm.args files there.

Fixes #98
