### PR TITLE
Add extra options to debuild template

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,6 +80,7 @@ The following variables describe a package and should be put in the
  - =freebsd_package_category= - The subsection the package is filed under in FreeBSD
    (ex: in this line, "ORIGIN: db/riak" 'db' would be the package_category)
    This defaults to 'db' if not specified for lack of a better default.
+ - =debuild_extra_options= - This is added to pass extra flags to debuild
 
 *** Script Variables
 The following variables are used in the =env.sh= and =runner= scripts which can

--- a/priv/templates/deb/Makefile
+++ b/priv/templates/deb/Makefile
@@ -9,6 +9,7 @@ default:
 		-e REVISION=$(PKG_VERSION) \
 		-e RELEASE=$(PKG_BUILD) \
                 -e REBAR=$(REBAR) \
+		{{debuild_extra_options}} \
 		-uc -us
 	mkdir -p ../packages
 	cd .. && mv *$(PKG_VERSION)-$(PKG_BUILD)_*.deb packages


### PR DESCRIPTION
Sometimes it is needed to pass extra variables such as environment variables into a build.  Debian is particularly harsh on environment variable cleaning so this gives the ability to add them in via the `pkg.vars.config`.
