### PR TITLE
Add optional support for specifying a NUMA policy

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -88,15 +88,16 @@ if [ -z "$COOKIE_ARG" ]; then
 fi
 
 # Optionally specify a NUMA policy
-NUMACTL_ARG=""
+NUMACTL_ARG="{{numactl_arg}}"
 if [ -z "$NUMACTL_ARG" ]
 then
     NUMACTL=""
+# Confirms `numactl` is in the path and validates $NUMACTL_ARG
 elif which numactl > /dev/null 2>&1 && numactl $NUMACTL_ARG ls /dev/null > /dev/null 2>&1
 then
     NUMACTL="numactl $NUMACTL_ARG"
 else
-    echoerr "NUMACTL_ARG is specified in env.sh but numactl is not installed."
+    echoerr "NUMACTL_ARG is specified in env.sh but numactl is not installed or NUMACTL_ARG is invalid."
     exit 1
 fi
 

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -87,6 +87,19 @@ if [ -z "$COOKIE_ARG" ]; then
     fi
 fi
 
+# Optionally specify a NUMA policy
+NUMACTL_ARG=""
+if [ -z "$NUMACTL_ARG" ]
+then
+    NUMACTL=""
+elif which numactl > /dev/null 2>&1 && numactl $NUMACTL_ARG ls /dev/null > /dev/null 2>&1
+then
+    NUMACTL="numactl $NUMACTL_ARG"
+else
+    echoerr "NUMACTL_ARG is specified in env.sh but numactl is not installed."
+    exit 1
+fi
+
 # Parse out release and erts info
 START_ERL=`cat $RUNNER_BASE_DIR/releases/start_erl.data`
 ERTS_VSN=${START_ERL% *}

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -329,7 +329,7 @@ case "$1" in
         BINDIR=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_SCRIPT \
+        CMD="$NUMACTL $BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_SCRIPT \
              $CONFIG_ARGS \
             -pa $RUNNER_PATCH_DIR -- ${1+"$@"}"
         export EMU


### PR DESCRIPTION
Provides a cleaner mechanism for specifying a NUMA policy when starting an Erlang VM.  

By default, no NUMA policy changes are implemented and numactl will not be executed, so systems that do not support NUMA will be unaffected.

To change the default NUMA policy, the user may edit env.sh and change the NUMACTL_ARG variable to include numactl parameters.  

Example:
NUMACTL_ARG="--interleave=all"

If a user specifies a numactl arg but numactl is not installed/available, then an error is thrown.
