### PR TITLE
Ensure word-splitting does not happen when re-running as other user.

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -196,7 +196,7 @@ check_user() {
             echoerr "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
             exit 1
         fi
-        exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
+        exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$@"
     fi
 }
 


### PR DESCRIPTION
Fixes basho/riak#471 (partially)
