### PR TITLE
Fix patch for smartos to add quotes

### DIFF
--- a/priv/templates/smartos/env.patch
+++ b/priv/templates/smartos/env.patch
@@ -1,4 +1,4 @@
 169c169
-<         exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
+<         exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$@"
 ---
->         exec sudo -H -u $RUNNER_USER $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
+>         exec sudo -H -u $RUNNER_USER $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$@"


### PR DESCRIPTION
env.sh got added quotes, so the patch file should follow.  I tested this against a broken SmartOS 13.1 build that is now fixed.
