### PR TITLE
Add chkconfig to install and uninstall scripts for RPMs

### DIFF
--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -102,13 +102,13 @@ cp -R %{relpath}/data/* \
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
 install -m755 %{_topdir}/init.script  %{buildroot}%{_sysconfdir}/init.d/{{package_install_name}}
 
-
 # Needed to work around check-rpaths which seems to be hardcoded into recent
 # RPM releases
 export QA_RPATHS=3
 
 
 %pre
+# Pre-install script
 if ! getent group {{package_install_group}} >/dev/null 2>&1; then
    groupadd -r {{package_install_group}}
 fi
@@ -122,12 +122,30 @@ else
            {{package_install_user}}
 fi
 
+
 %post
+# Post Installation Script
+
 # Fixup perms for SELinux (if it is enabled)
 selinuxenabled && find %{_localstatedir}/lib/{{package_install_name}} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
 
 # Make sure shell library file is readable
 chmod 0755 %{_libdir}/{{package_install_name}}/lib/env.sh
+
+# Add application to chkconfig, but default to "off"
+/sbin/chkconfig --add {{package_install_name}}
+/sbin/chkconfig {{package_install_name}} off
+
+
+%preun
+# Pre-uninstall script
+
+# Only on uninstall, not upgrades
+if [ "$1" = 0 ] ; then
+   /sbin/service {{package_install_name}} stop > /dev/null 2>&1
+   /sbin/chkconfig --del {{package_install_name}}
+fi
+exit 0
 
 
 # Man pages are optional and might be missing, read from file


### PR DESCRIPTION
Addresses: #110

This adds the app to chkconfig in the post install script, and
likewise removes it in the uninstall step.  It is based
on the usage documented at
http://fedoraproject.org/wiki/Packaging%3aScriptletSnippets
- [x] - Code Review
- [x] - Package Test (install, uninstall)
