### PR TITLE
force nodetool's encoding to be unicode

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -1,4 +1,5 @@
 #!/usr/bin/env escript
+%%! +fnu
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 %% -------------------------------------------------------------------
@@ -10,6 +11,7 @@
 %% installed by node_package (github.com/basho/node_package)
 
 main(Args) ->
+    io:setopts([{encoding, utf8}]),
     ok = start_epmd(),
     %% Extract the args
     {RestArgs, TargetNode} = process_args(Args, [], undefined),


### PR DESCRIPTION
This PR changes nodetool from using latin1 (character set and encoding) to UTF-8 encoded Unicode characters. This affects how nodetool decodes input from the command-line & stdin, and how it encodes to stdout. 

To force the use of UTF-8 and because escripts default to latin1 [1] [2], `io:setopts/1` [1] is used to set the encoding for the standard IO devices to `utf8`.

To force command-line arguments to be decoded from UTF-8 into a Erlang list of unicode codepoints, reliably across platforms, the `+fnu` argument is added to nodetool via escript's vm arguments comment. The `+fnu` flag controls whether or not Erlang assumes filenames are represented in some Unicode encoding (usually UTF-8), referred to as "Unicode File Name Translation" or encoded in latin1, "bytewise encoding". On OS X and Windows Unicode File Name Translation is enabled by default. On Linux, it is not.  Adding `+fnu` has the effect of changing it for all platforms.  [3] indicates that command-line (and environment variables)  are assumed to be encoded in the same way as file names.  All the details can be found in [4] and [5].  

[1] http://erlang.org/doc/man/io.html#setopts-1
[2] http://erlang.org/pipermail/erlang-questions/2014-March/078154.html
[3] http://www.erlang.org/doc/apps/stdlib/unicode_usage.html#id62041
[4] http://erlang.org/pipermail/erlang-questions/2014-March/078329.html
[5] http://www.erlang.org/doc/apps/stdlib/unicode_usage.html
