### PR TITLE
Change prctl calls from `-t basic` to `-t system` for SmartOS

### DIFF
--- a/priv/templates/smartos/runner.patch
+++ b/priv/templates/smartos/runner.patch
@@ -12,11 +12,11 @@
 <         check_ulimit
 ---
 >         # Make sure we have access to enough file descriptors
->         ULIMIT_S=$(prctl -n process.max-file-descriptor -t basic -P $$ | awk '/max-file-descriptor/ { print $3 }')
+>         ULIMIT_S=$(prctl -n process.max-file-descriptor -t system -P $$ | awk '/max-file-descriptor/ { print $3 }')
 >         ULIMIT_H=$(prctl -n process.max-file-descriptor -t priv -P $$ | awk '/max-file-descriptor/ { print $3 }')
 >         if [ ${ULIMIT_S} -lt ${ULIMIT_H} ]; then
 >             echo "Trying to raise the file descriptor limit to maximum allowed."
->             prctl -n process.max-file-descriptor -t basic -v ${ULIMIT_H} $$ || true
+>             prctl -n process.max-file-descriptor -t system -v ${ULIMIT_H} $$ || true
 >         fi
 116a129
 > 
@@ -32,9 +32,9 @@
 <         check_ulimit
 ---
 >         # Make sure we have access to enough file descriptors
->         ULIMIT_S=$(prctl -n process.max-file-descriptor -t basic -P $$ | awk '/max-file-descriptor/ { print $3 }')
+>         ULIMIT_S=$(prctl -n process.max-file-descriptor -t system -P $$ | awk '/max-file-descriptor/ { print $3 }')
 >         ULIMIT_H=$(prctl -n process.max-file-descriptor -t priv -P $$ | awk '/max-file-descriptor/ { print $3 }')
 >         if [ ${ULIMIT_S} -lt ${ULIMIT_H} ]; then
 >             echo "Trying to raise the file descriptor limit to maximum allowed."
->             prctl -n process.max-file-descriptor -t basic -v ${ULIMIT_H} $$ || true
+>             prctl -n process.max-file-descriptor -t system -v ${ULIMIT_H} $$ || true
 >         fi


### PR DESCRIPTION
Newer global zones of SmartOS changed the behavior of `prctl`.
The man pages still show `-t basic` as being a valid flag, but
a user reported it no longer worked in practice in #117.  This
change fixes that issue according to Joyent's recommendation.

I tested this on datasets 1.6, 1.8, 13.1 by installing the packages, starting with `svcadm enable -r riak`, attaching via `sudo riak attach` and checking `os:cmd('ulimit -n').` which printed the correct value.
