### PR TITLE
Replace sudo in runner scripts with su for greater compatibility

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -151,18 +151,8 @@ EOF
 
 }
 
-# All commands must either call bootstrap or bootstrapd
-# Call bootstrap for non-daemon commands like ping or chkconfig
-# Call bootstrapd for daemon commands like start/stop/console
-bootstrap() {
-    # Make sure the user running this script is the owner and/or su to that user
-    check_user $@
-    ES=$?
-    if [ "$ES" -ne 0 ]; then
-        exit $ES
-    fi
-}
 
+# Call bootstrapd for daemon commands like start/stop/console
 bootstrapd() {
     # Create PID directory if it does not exist before dropping permissiongs
     # to the runner user
@@ -173,8 +163,12 @@ bootstrapd() {
         exit 1
     fi
 
-    # Now call bootstrap to drop to $RUNNER_USER
-    bootstrap $@
+    # Make sure the user running this script is the owner and/or su to that user
+    check_user $@
+    ES=$?
+    if [ "$ES" -ne 0 ]; then
+        exit $ES
+    fi
 }
 
 # Check the first argument for instructions
@@ -286,9 +280,6 @@ case "$1" in
         ;;
 
     ping)
-        # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap $@
-
         ## See if the VM is alive
         ping_node
         ES=$?
@@ -375,9 +366,6 @@ case "$1" in
         ;;
 
     top)
-        # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap $@
-
         # Make sure the local node IS running
         node_up_check
 
@@ -397,15 +385,12 @@ case "$1" in
         ;;
 
     chkconfig)
-        # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap $@
+        bootstrapd $@
 
         check_config
         ;;
 
     config)
-        bootstrap $@
-
         shift
         if [ -z "$CUTTLEFISH" ]; then
             echo "This application is not configured to use cuttlefish."
@@ -439,9 +424,6 @@ case "$1" in
         ;;
 
     escript)
-        # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap $@
-
         shift
         $ERTS_PATH/escript "$@"
         ES=$?
@@ -455,9 +437,6 @@ case "$1" in
         ;;
 
     getpid)
-        # Bootstrap command (simply drop to $RUNNER_USER)
-        bootstrap $@
-
         # Get the PID from nodetool
         get_pid
         ES=$?

--- a/priv/templates/deb/control
+++ b/priv/templates/deb/control
@@ -8,7 +8,6 @@ Homepage: {{vendor_url}}
 
 Package: {{package_name}}
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, logrotate, sudo, {{deb_depends}}
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, logrotate, {{deb_depends}}
 Description: {{package_shortdesc}}
   {{package_desc}}
-

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -15,8 +15,6 @@ BUILD_STAGE_DIR = $(BUILDDIR)/$(PACKAGE_NAME_CLEAN)
 ##   1.6          0.9.8knb1      5.4nb1
 ##   1.8          0.9.8knb1      5.4nb1
 ##  13.1          1.0.1c         5.4nb1
-## ## Additional Deps for runner
-## sudo (same for all versions)
 ##
 ## ## SMF Manifest Mapping
 ##   SmartOS     Manifest File
@@ -110,7 +108,6 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	@echo "Adding to packaging list $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)"
 	echo "@name $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)" >> plist
 	echo "@pkgcfl $(PACKAGE_NAME_CLEAN)-*" >> plist
-	echo "@pkgdep sudo-[0-9]*" >> plist
 	echo "@pkgdep $(OPENSSL_DEP)" >> plist
 	echo "@pkgdep $(NCURSES_DEP)" >> plist
 	echo "@pkgdep $(GCC_DEP)" >> plist
@@ -237,13 +234,9 @@ smartos_check:
 # Patch the runner script with SmartOS modifications
 patch_runner: buildrel
 	cp $(PKGERDIR)/runner.patch $(BUILDDIR)/rel/{{package_install_name}}/bin/
-	cp $(PKGERDIR)/env.patch $(BUILDDIR)/rel/{{package_install_name}}/lib/
 	cd $(BUILDDIR)/rel/{{package_install_name}}/bin && \
 	   patch -p0 {{package_install_name}} runner.patch
 	rm $(BUILDDIR)/rel/{{package_install_name}}/bin/runner.patch
-	cd $(BUILDDIR)/rel/{{package_install_name}}/lib && \
-	patch -p0 env.sh env.patch
-	rm $(BUILDDIR)/rel/{{package_install_name}}/lib/env.patch
 
 
 # Build the release we need to package

--- a/priv/templates/smartos/env.patch
+++ b/priv/templates/smartos/env.patch
@@ -1,4 +1,0 @@
-169c169
-<         exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$@"
----
->         exec sudo -H -u $RUNNER_USER $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$@"

--- a/priv/templates/smartos/smartos.template
+++ b/priv/templates/smartos/smartos.template
@@ -32,4 +32,3 @@
 {template, "manifest131.xml", "manifest131.xml"}.
 {template, "epmd", "epmd"}.
 {template, "runner.patch", "runner.patch"}.
-{template, "env.patch", "env.patch"}.


### PR DESCRIPTION
Fixes: basho/node_package#125

This has been a much needed change for a long time.  Requiring
sudo made for unhappy admin's and difficulty supporting all
OS's equally.  This also removes the need to install sudo on
OS's that don't typically ship with it, FreeBSD, Solaris, etc.

In addition this fix makes the `tail` command used several times
so that it works on solaris without using xpg4's tail.
