### PR TITLE
Add packaging for FreeBSD pkg-ng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ endif
 ifeq ($(OS),FreeBSD)
 OSNAME        = FreeBSD
 ARCH          = $(shell uname -m)
-PKGERDIR      = fbsd
 BUILDDIR      = fbsdbuild
+PKGNG         = $(shell uname -r | awk -F. '{ print ($$1 > 9) ? "true" : "false" }')
+ifeq ($(PKGNG),true)        # FreeBSD 10.0 or greater
+PKGERDIR      = fbsdng
+else                        # Older FreeBSD pkg_add 
+PKGERDIR      = fbsd
+endif
 endif
 
 ifeq ($(OS),SunOS)         # Solaris flavors

--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -197,17 +197,27 @@ create_pid_file() {
     fi
 }
 
-# Function to su into correct user
-check_user() {
+
+# Simple way to check the correct user and fail early
+check_user_internal() {
     # Validate that the user running the script is the owner of the
     # RUN_DIR.
     if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
-        if [ "x$WHOAMI" = "xroot" ]; then
-            exec su - $RUNNER_USER -c "$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $*"
-        else
+        if [ "x$WHOAMI" != "xroot" ]; then
             echo "You need to be root or use sudo to run this command"
             exit 1
         fi
+    fi
+}
+
+# Function to su into correct user that is poorly named for historical
+# reasons (excuses)
+check_user() {
+    check_user_internal
+
+    # do not su again if we are already the runner user
+    if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
+        exec su - $RUNNER_USER -c "$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $*"
     fi
 }
 

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -154,6 +154,9 @@ EOF
 
 # Call bootstrapd for daemon commands like start/stop/console
 bootstrapd() {
+    # Fail fast if they have no rights to mess around with pids
+    check_user_internal
+
     # Create PID directory if it does not exist before dropping permissiongs
     # to the runner user
     create_pid_dir

--- a/priv/templates/fbsdng/+MANIFEST
+++ b/priv/templates/fbsdng/+MANIFEST
@@ -1,0 +1,18 @@
+name: {{package_name}}
+origin: {{freebsd_package_category}}
+comment: {{package_shortdesc}}
+licenses: [{{license_type}}]
+licenselogic: single
+arch: freebsd:10:x86:64
+www: {{vendor_url}}
+maintainer: {{vendor_contact_email}}
+users: [{{package_install_user}}]
+groups: [{{package_install_group}}]
+prefix: /usr/local
+categories: [{{freebsd_package_category}}]
+desc: "{{package_desc}}"
+scripts:
+  pre-install: |-
+    if ! pw groupshow {{package_install_group}} 2>/dev/null; then pw groupadd {{package_install_group}}; fi
+    if ! pw usershow {{package_install_user}} 2>/dev/null; then pw useradd {{package_install_user}} -g {{package_install_group}} -h - -d {{platform_data_dir}} -s /bin/sh -c \"{{package_install_user_desc}}\"; fi
+    if [ ! -d /var/log/{{package_install_name}} ]; then mkdir /var/log/{{package_install_name}} && chown {{package_install_user}}:{{package_install_group}} /var/log/{{package_install_name}}; fi

--- a/priv/templates/fbsdng/Makefile
+++ b/priv/templates/fbsdng/Makefile
@@ -1,0 +1,98 @@
+BUILDDIR        = $(shell pwd)
+BUILD_STAGE_DIR = $(BUILDDIR)/{{package_name}}
+
+# Where we install things (based on vars.config)
+# /usr/local based dirs
+PMAN_DIR         = $(BUILD_STAGE_DIR)/usr/local/man
+PBIN_DIR         = $(BUILD_STAGE_DIR)/{{platform_bin_dir}}
+PETC_DIR         = $(BUILD_STAGE_DIR)/{{platform_etc_dir}}
+PLIB_DIR         = $(BUILD_STAGE_DIR)/{{platform_base_dir}}
+# /var based dirs
+PDATA_DIR        = $(BUILD_STAGE_DIR)/{{platform_data_dir}}
+PLOG_DIR         = $(BUILD_STAGE_DIR)/var/log/{{package_install_name}}
+
+# For scanning later, remove the leading slash
+# '/var/db/server' becomes 'var/db/server'
+PDATA_ROOT_DIR   = $(shell echo "{{platform_data_dir}}" | cut -d'/' -f 2-4)
+
+TARNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
+PKGNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tbz
+
+
+# Recursive assignment of ERTS version
+# We will know this after building the rel
+ERTS_PATH = $(shell ls $(BUILDDIR)/rel/{{package_install_name}} | egrep -o "erts-.*")
+
+build: packing_list_files
+	@echo "Building package $(PKGNAME)"
+
+	cd $(BUILD_STAGE_DIR) && \
+	mkdir ../../packages && \
+	pkg create -m . -r . -o ../../packages
+
+	cd ../packages && \
+		for tarfile in *.txz; do \
+		shasum -a 256 $${tarfile} > $${tarfile}.sha \
+	; done
+
+packing_list_files: $(BUILD_STAGE_DIR)
+	@mv ${BUILDDIR}/fbsdng/+MANIFEST ${BUILD_STAGE_DIR}
+	sed -e "s/%ERTS_PATH%/${ERTS_PATH}/" < \
+		${BUILDDIR}/fbsdng/rc.d > ${BUILD_STAGE_DIR}/usr/local/etc/rc.d/{{package_install_name}}
+	chmod -w ${BUILD_STAGE_DIR}/usr/local/etc/rc.d/{{package_install_name}}
+	chmod +x ${BUILD_STAGE_DIR}/usr/local/etc/rc.d/{{package_install_name}}
+	@cd $(BUILD_STAGE_DIR) && \
+		echo "version: ${PKG_VERSION}" >> +MANIFEST && \
+		echo "files:" >> +MANIFEST
+
+	@echo "Copying Man pages to staging directory"
+	@cd $(BUILDDIR) && \
+	if [ -d doc/man/man1 ]; then \
+		mkdir -p $(PMAN_DIR) && \
+		cp -R doc/man/man1 $(PMAN_DIR); fi
+
+	@echo "Packaging /usr/local files"
+	@cd $(BUILD_STAGE_DIR) && \
+	find usr -type f | while read file ; do \
+	    mode=$$(stat -f%p "$$file" | cut -c 3-) && \
+	    sum=$$(sha256 -q $$file) && \
+	    echo "  /$$file: { sum: $$sum, perm: $$mode, uname: root, gname: wheel }" >> +MANIFEST; done
+
+	@cd $(BUILD_STAGE_DIR) && \
+		echo "directories:" >> +MANIFEST && \
+		echo "  {{platform_base_dir}}: {}" >> +MANIFEST && \
+		echo "  {{platform_data_dir}}: {uname: {{package_install_user}}, gname: {{package_install_group}}, perm: 0700 }" >> +MANIFEST && \
+		echo "  {{platform_etc_dir}}: {}" >> +MANIFEST
+
+# Copy the app rel directory to the staging directory to build our
+# package structure and move the directories into the right place
+# for the package, see the vars.config file for destination
+# directories
+$(BUILD_STAGE_DIR): buildrel
+	@echo "Copying rel directory to staging directory"
+	mkdir -p $@
+	mkdir -p $(PBIN_DIR)
+	cp -R rel/{{package_install_name}}/bin/* $(PBIN_DIR)
+	mkdir -p $(PETC_DIR)
+	cp -R rel/{{package_install_name}}/etc/* $(PETC_DIR)
+	mkdir -p $(PLIB_DIR)
+	cp -R rel/{{package_install_name}}/lib $(PLIB_DIR)
+	cp -R rel/{{package_install_name}}/erts-* $(PLIB_DIR)
+	cp -R rel/{{package_install_name}}/releases $(PLIB_DIR)
+	mkdir -p $(PDATA_DIR)
+	cp -R rel/{{package_install_name}}/data/* $(PDATA_DIR)
+	mkdir -p ${BUILD_STAGE_DIR}/usr/local/etc/rc.d
+
+
+# Build the release we need to package
+#  * Ensure all binaries are executable
+#  * copy the vars.config over for build config
+buildrel:
+	OVERLAY_VARS="overlay_vars=../fbsdng/vars.config" $(MAKE) deps rel
+	chmod 0755 rel/{{package_install_name}}/bin/* rel/{{package_install_name}}/erts-*/bin/*
+
+$(BUILDDIR):
+	mkdir -p $@
+
+$(PKGERDIR)/pkgclean:
+	rm -rf $(BUILD_STAGE_DIR) $(BUILDDIR)

--- a/priv/templates/fbsdng/Makefile.bootstrap
+++ b/priv/templates/fbsdng/Makefile.bootstrap
@@ -1,0 +1,12 @@
+
+##
+## Export all variables to sub-invocation
+##
+export
+
+bootstrap:
+	mkdir -p $(PKG_ID)/fbsdng
+	cd $(PKG_ID)/fbsdng && $(REBAR) -v create \
+                                template_dir=../$(DEPS_DIR)/node_package/priv/templates \
+                                template_vars=../pkg.vars.config template=fbsdng
+	$(MAKE) -C $(PKG_ID) -f fbsdng/Makefile

--- a/priv/templates/fbsdng/fbsdng.template
+++ b/priv/templates/fbsdng/fbsdng.template
@@ -1,0 +1,25 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+%%
+{variables, [
+             {package_name, "package_name"},
+             {package_install_name, "package_install_name"},
+             {package_install_user, "package_install_user"},
+             {package_install_user_desc, "package_install_user_desc"},
+             {package_install_group, "package_install_group"},
+             {bin_or_sbin, "bin"},
+             {freebsd_package_category, "db"},
+
+             %% Platform-specific installation paths
+             {platform_bin_dir,  "/usr/local/{{bin_or_sbin}}"},
+             {platform_data_dir, "/usr/local/{{package_install_name}}"},
+             {platform_etc_dir,  "/usr/local/etc/{{package_install_name}}"},
+             {platform_base_dir, "/usr/local/lib/{{package_install_name}}"},
+             {platform_lib_dir,  "/usr/local/lib/{{package_install_name}}/lib"},
+             {platform_log_dir,  "/var/log/{{package_install_name}}"}
+            ]
+}.
+{template, "Makefile", "Makefile"}.
+{template, "vars.config", "vars.config"}.
+{template, "+MANIFEST", "+MANIFEST"}.
+{template, "rc.d", "rc.d"}.

--- a/priv/templates/fbsdng/rc.d
+++ b/priv/templates/fbsdng/rc.d
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# $FreeBSD$
+#
+# PROVIDE: {{package_install_name}}
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name={{package_install_name}}
+command={{platform_base_dir}}/%ERTS_PATH%/bin/beam.smp
+rcvar={{package_install_name}}_enable
+start_cmd="{{platform_bin_dir}}/${name} start"
+stop_cmd="{{platform_bin_dir}}/${name} stop"
+pidfile="/var/run/${name}/${name}.pid"
+
+load_rc_config $name
+run_rc_command "$1"

--- a/priv/templates/fbsdng/vars.config
+++ b/priv/templates/fbsdng/vars.config
@@ -1,0 +1,20 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "{{platform_bin_dir}}"}.
+{platform_data_dir, "{{platform_data_dir}}"}.
+{platform_etc_dir,  "{{platform_etc_dir}}"}.
+{platform_base_dir, "{{platform_base_dir}}"}.
+{platform_lib_dir,  "{{platform_lib_dir}}"}.
+{platform_log_dir,  "{{platform_log_dir}}"}.
+
+%% TODO can we just get rid of these?
+{runner_script_dir,  "{{platform_bin_dir}}"}.
+{runner_base_dir,    "{{platform_base_dir}}"}.
+{runner_etc_dir,     "{{platform_etc_dir}}"}.
+{runner_log_dir,     "{{platform_log_dir}}"}.
+{runner_user,        "{{package_install_user}}"}.
+{runner_lib_dir,     "{{platform_lib_dir}}"}.
+{runner_patch_dir,   "{{platform_lib_dir}}/{{package_patch_dir}}"}.
+{pipe_dir,           "/tmp/{{package_install_name}}/"}.


### PR DESCRIPTION
With FreeBSD 10, pkg-ng (or pkg) has become the default and
suggested packaging tool.  This adds support for pkgng on
FreeBSD 10.

This also addresses: #118 
