### PR TITLE
Remove reboot from runner script

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -21,7 +21,7 @@ usage() {
 cat <<EOF
 Usage: $SCRIPT «command»
 where «command» is one of the following:
-    { help | start | stop | restart | reboot | ping | console | attach
+    { help | start | stop | restart | ping | console | attach
       attach-direct | ertspath | chkconfig | escript | version | getpid
       top [-interval N] [-sort { reductions | memory | msg_q }] [-lines N] } |
       config { generate | effective | describe VARIABLE } [-l debug]
@@ -59,12 +59,6 @@ This is the primary script for controlling the $SCRIPT node.
         Stops and then starts the running $SCRIPT node without exiting the
         Erlang VM.  Prints "ok" when successful.  When the node is already
         stopped or not responding, prints:
-        "Node '$NAME_HOST' not responding to pings."
-
-    reboot
-        Stops and then starts the running $SCRIPT node, exiting the Erlang VM.
-        Prints "ok" when successful.  When the node is already stopped or not
-        responding, prints:
         "Node '$NAME_HOST' not responding to pings."
 
     console
@@ -264,18 +258,6 @@ case "$1" in
 
         ## Restart the VM without exiting the process
         $NODETOOL restart
-        ES=$?
-        if [ "$ES" -ne 0 ]; then
-            exit $ES
-        fi
-        ;;
-
-    reboot)
-        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
-        bootstrapd $@
-
-        ## Restart the VM completely (uses heart to restart it)
-        $NODETOOL reboot
         ES=$?
         if [ "$ES" -ne 0 ]; then
             exit $ES


### PR DESCRIPTION
`riak reboot` hasn't worked in a long long time, because it needs heart support in erlang and we don't ship with that by default.  This removal is long overdue.

Fixes: #131 basho/riak#162 by complete removal of the broken command
