### PR TITLE
Set HOME env var and proper perms on nodetool in Ubuntu

### DIFF
--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -21,6 +21,13 @@ SCRIPTNAME=/etc/init.d/$NAME
 . /lib/init/vars.sh
 . /lib/lsb/init-functions
 
+# `service` strips all environmental VARS so
+# if no HOME was set in /etc/default/$NAME then set one here
+# to the data directory for erlexec's sake
+if [ -z "$HOME" ]; then
+    export HOME={{platform_data_dir}}
+fi
+
 #
 # Function that starts the daemon/service
 #

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -33,6 +33,7 @@ chmod 0755 /var/run/{{package_install_name}} /etc/{{package_install_name}}
 chmod 0644 /etc/{{package_install_name}}/*
 chmod -R +X /etc/{{package_install_name}}
 chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
+chmod 0755 /usr/lib/{{package_install_name}}/erts-*/bin/nodetool
 
 case "$1" in
     configure)

--- a/priv/templates/rpm/init.script
+++ b/priv/templates/rpm/init.script
@@ -29,6 +29,13 @@ pidfile=/var/run/$NAME/$NAME.pid
 # Read configuration variable file if it is present and readable
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 
+# `service` strips all environmental VARS so
+# if no HOME was set in /etc/default/$NAME then set one here
+# to the data directory for erlexec's sake
+if [ -z "$HOME" ]; then
+    export HOME={{platform_data_dir}}
+fi
+
 status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
 


### PR DESCRIPTION
- The `service` command strips environmental variables, which
  casued issues with `erlexec` when it couldn't find $HOME.
  This fixes that issue: #135
- Ubuntu 12.04 had improper permissions set on nodetool, so this
  ensures it is executable by non-priviledged users at bootstrap.
  This fixes that issue: #136
