### PR TITLE
Add basic support for SuSE Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ ifeq ($(OS),Linux)
 ARCH          = $(shell uname -m)
 ISRPM         = $(shell cat /etc/redhat-release 2> /dev/null)
 ISDEB         = $(shell cat /etc/debian_version 2> /dev/null)
+ISSLES        = $(shell cat /etc/SuSE-release 2> /dev/null)
 ifneq ($(ISRPM),)
-OSNAME= RedHat
+OSNAME        = RedHat
 PKGERDIR      = rpm
 BUILDDIR      = rpmbuild
 else
@@ -23,6 +24,12 @@ ifneq ($(ISDEB),)
 OSNAME        = Debian
 PKGERDIR      = deb
 BUILDDIR      = debuild
+else
+ifneq ($(ISSLES),)
+OSNAME        = SLES
+PKGERDIR      = rpm
+BUILDDIR      = rpmbuild
+endif  # SLES
 endif  # deb
 endif  # rpm
 endif  # linux
@@ -42,7 +49,7 @@ BUILDDIR      = fbsdbuild
 PKGNG         = $(shell uname -r | awk -F. '{ print ($$1 > 9) ? "true" : "false" }')
 ifeq ($(PKGNG),true)        # FreeBSD 10.0 or greater
 PKGERDIR      = fbsdng
-else                        # Older FreeBSD pkg_add 
+else                        # Older FreeBSD pkg_add
 PKGERDIR      = fbsd
 endif
 endif

--- a/priv/templates/rpm/Makefile
+++ b/priv/templates/rpm/Makefile
@@ -1,12 +1,21 @@
 
 PWD    = $(shell pwd)
+
+
+ifeq ($(OSNAME),RedHat)
 DISTRO = $(shell head -1 /etc/redhat-release| awk \
            '{if ($$0 ~ /CentOS release 5/) { print ".el5."} else { print "." }} ')
+INITSCRIPT=rhel.init.script
+endif
+ifeq ($(OSNAME),SLES)
+DISTRO = .SLES$(shell grep VERSION /etc/SuSE-release | cut -d ' ' -f 3).
+INITSCRIPT=suse.init.script
+endif
 
 # No hyphens are allowed in the _version field in RPM
 PKG_VERSION_NO_H	?= $(shell echo $(PKG_VERSION) | tr - .)
 
-default:
+default: init.script
 	mkdir -p BUILD
 	mkdir -p packages
 	rpmbuild --define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}$(DISTRO)%%{ARCH}.rpm" \
@@ -25,3 +34,6 @@ default:
 		for rpmfile in *.rpm; do \
 			sha256sum $${rpmfile} > $${rpmfile}.sha \
 		; done
+
+init.script:
+	cp $(INITSCRIPT) init.script

--- a/priv/templates/rpm/rhel.init.script
+++ b/priv/templates/rpm/rhel.init.script
@@ -1,0 +1,152 @@
+#!/bin/sh
+#
+# {{package_name}}
+#
+# chkconfig: 2345 80 30
+# description: {{package_shortdesc}}
+# processname: beam
+# config: /etc/{{package_install_name}}/app.config
+# config: /etc/{{package_install_name}}/vm.args
+# config: /etc/sysconfig/{{package_install_name}}
+#
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+RETVAL=0
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="{{package_shortdesc}}"
+NAME={{package_install_name}}
+DAEMON=/usr/{{bin_or_sbin}}/$NAME
+lockfile=/var/lock/subsys/$NAME
+pidfile=/var/run/$NAME/$NAME.pid
+
+# Check for script, config and data dirs
+[ -x /usr/{{bin_or_sbin}}/$NAME ] || exit 0
+[ -d /etc/$NAME ] || exit 0
+[ -d /var/lib/$NAME ] || exit 0
+
+# Read configuration variable file if it is present and readable
+[ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+
+# `service` strips all environmental VARS so
+# if no HOME was set in /etc/sysconfig/$NAME then set one here
+# to the data directory for erlexec's sake
+if [ -z "$HOME" ]; then
+    export HOME={{platform_data_dir}}
+fi
+
+status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
+running=$?
+
+check_pid_status() {
+    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+    if [ "$pid" = "" ]; then
+        # prog not running?
+        return 1
+    else
+        # running
+        return 0
+    fi
+}
+
+start() {
+    # Start daemons.
+    echo -n $"Starting {{package_install_name}}: "
+    $DAEMON start
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+        touch $lockfile
+        success
+    else
+        failure $"$NAME start"
+    fi
+    echo
+    return $RETVAL
+}
+
+stop() {
+    # Stop daemon.
+    echo -n $"Shutting down {{package_install_name}}: "
+    $DAEMON stop 2>/dev/null
+    for n in $(seq 1 10); do
+        sleep 1
+        check_pid_status
+        RETVAL=$?
+        if [ $RETVAL -eq 1 ]; then
+            break
+        fi
+    done
+    if [ $RETVAL -eq 1 ]; then
+        rm -f $lockfile $pidfile
+        success
+        echo && return 0
+    else
+        failure $"$NAME stop"
+        echo && return 1
+    fi
+}
+
+hardstop() {
+    echo -n $"Shutting down $NAME: "
+    su - {{package_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
+    for n in $(seq 1 10); do
+        sleep 1
+        check_pid_status
+        RETVAL=$?
+        if [ $RETVAL -eq 1 ]; then
+            break
+        fi
+    done
+    if [ $RETVAL -eq 1 ]; then
+        rm -f $lockfile $pidfile
+        success
+        echo && return 0
+    else
+        failure $"$NAME hardstop"
+        echo && return 1
+    fi
+}
+
+# See how we were called.
+case "$1" in
+    start)
+        [ $running -eq 0 ] && exit 0
+        start
+        ;;
+    stop)
+        if [ $running -eq 0 ]; then
+            stop
+        else
+            check_pid_status
+            RETVAL=$?
+            if [ $RETVAL -eq 1 ]; then
+                rm -f $lockfile $pidfile
+            fi
+            exit 0
+        fi
+        ;;
+    restart|force-reload)
+        [ $running -eq 0 ] && stop
+        start
+        ;;
+    hardstop)
+        [ $running -eq 0 ] || exit 0
+        hardstop
+        ;;
+    condrestart|try-restart)
+        [ $running -eq 0 ] || exit 0
+        restart
+        ;;
+    status)
+        status -p $pidfile -l $(basename $lockfile) $NAME
+        ;;
+    ping)
+        $DAEMON ping || exit $?
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|try-restart|status|ping}"
+        exit 1
+esac
+
+exit $?

--- a/priv/templates/rpm/rpm.template
+++ b/priv/templates/rpm/rpm.template
@@ -17,4 +17,5 @@
 }.
 {template, "Makefile", "Makefile"}.
 {template, "specfile", "specfile"}.
-{template, "init.script", "init.script"}.
+{template, "rhel.init.script", "rhel.init.script"}.
+{template, "suse.init.script", "suse.init.script"}.

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -1,8 +1,22 @@
-# _revision, _release, and _version should be defined on the rpmbuild command
-# line like so:
-#
-# --define "_version 0.9.1.19.abcdef" --define "_release 7" \
-# --define "_revision 0.9.1-19-abcdef"
+## -------------------------------------------------------------------
+##
+## Copyright (c) 2014 Basho Technologies, Inc.
+##
+## This file is provided to you under the Apache License,
+## Version 2.0 (the "License"); you may not use this file
+## except in compliance with the License.  You may obtain
+## a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+##
+## -------------------------------------------------------------------
 
 Name: {{package_name}}
 Version: %{_version}
@@ -119,6 +133,7 @@ else
    useradd -r -g {{package_install_group}} \
            --home %{_localstatedir}/lib/{{package_install_name}} \
            --comment "{{package_install_user_desc}}" \
+           --shell /bin/bash \
            {{package_install_user}}
 fi
 
@@ -126,8 +141,11 @@ fi
 %post
 # Post Installation Script
 
-# Fixup perms for SELinux (if it is enabled)
-selinuxenabled && find %{_localstatedir}/lib/{{package_install_name}} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
+# For distros with SELinux (RHEL/Fedora)
+if [ `which selinuxenabled > /dev/null 2>&1` ] ; then
+   # Fixup perms for SELinux (if it is enabled)
+   selinuxenabled && find %{_localstatedir}/lib/{{package_install_name}} -name "*.so" -exec chcon -t textrel_shlib_t {} \;
+fi
 
 # Make sure shell library file is readable
 chmod 0755 %{_libdir}/{{package_install_name}}/lib/env.sh

--- a/priv/templates/rpm/suse.init.script
+++ b/priv/templates/rpm/suse.init.script
@@ -2,16 +2,18 @@
 #
 # {{package_name}}
 #
-# chkconfig: 2345 80 30
-# description: {{package_shortdesc}}
-# processname: beam
-# config: /etc/{{package_install_name}}/app.config
-# config: /etc/{{package_install_name}}/vm.args
-# config: /etc/sysconfig/{{package_install_name}}
-#
+### BEGIN INIT INFO
+# Provides:          {{package_name}}
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: {{package_shortdesc}}
+# Description:       {{package_desc}}
+### END INIT INFO
 
-# Source function library.
-. /etc/rc.d/init.d/functions
+# Source the LSB function library.
+. /lib/lsb/init-functions
 
 RETVAL=0
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
@@ -30,14 +32,16 @@ pidfile=/var/run/$NAME/$NAME.pid
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 
 # `service` strips all environmental VARS so
-# if no HOME was set in /etc/default/$NAME then set one here
+# if no HOME was set in /etc/sysconfig/$NAME then set one here
 # to the data directory for erlexec's sake
 if [ -z "$HOME" ]; then
     export HOME={{platform_data_dir}}
 fi
 
-status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
-running=$?
+# Checks the status of a node
+do_status() {
+    $DAEMON ping >/dev/null 2>&1 && return 0 || return 3
+}
 
 check_pid_status() {
     pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
@@ -50,22 +54,22 @@ check_pid_status() {
     fi
 }
 
-start() {
+do_start() {
     # Start daemons.
     echo -n $"Starting {{package_install_name}}: "
     $DAEMON start
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then
         touch $lockfile
-        success
+        log_success_msg
     else
-        failure $"$NAME start"
+        log_failure_msg $"$NAME start"
     fi
     echo
     return $RETVAL
 }
 
-stop() {
+do_stop() {
     # Stop daemon.
     echo -n $"Shutting down {{package_install_name}}: "
     $DAEMON stop 2>/dev/null
@@ -79,15 +83,15 @@ stop() {
     done
     if [ $RETVAL -eq 1 ]; then
         rm -f $lockfile $pidfile
-        success
+        log_success_msg
         echo && return 0
     else
-        failure $"$NAME stop"
+        log_failure_msg $"$NAME stop"
         echo && return 1
     fi
 }
 
-hardstop() {
+do_hardstop() {
     echo -n $"Shutting down $NAME: "
     su - {{package_install_user}} -c "ps -ef | grep beam.smp | grep '\-progname $NAME ' | grep -v grep | awk '{print \$2}' | xargs kill -9"
     for n in $(seq 1 10); do
@@ -100,10 +104,10 @@ hardstop() {
     done
     if [ $RETVAL -eq 1 ]; then
         rm -f $lockfile $pidfile
-        success
+        log_success_msg
         echo && return 0
     else
-        failure $"$NAME hardstop"
+        log_failure_msg $"$NAME hardstop"
         echo && return 1
     fi
 }
@@ -111,12 +115,12 @@ hardstop() {
 # See how we were called.
 case "$1" in
     start)
-        [ $running -eq 0 ] && exit 0
-        start
+        do_status && exit 0
+        do_start
         ;;
     stop)
-        if [ $running -eq 0 ]; then
-            stop
+        if do_status; then
+            do_stop
         else
             check_pid_status
             RETVAL=$?
@@ -126,26 +130,26 @@ case "$1" in
             exit 0
         fi
         ;;
-    restart|force-reload)
-        [ $running -eq 0 ] && stop
-        start
+    restart|reload|force-reload)
+        do_status && do_stop
+        do_start
         ;;
     hardstop)
-        [ $running -eq 0 ] || exit 0
-        hardstop
+        do_status || exit 0
+        do_hardstop
         ;;
     condrestart|try-restart)
-        [ $running -eq 0 ] || exit 0
-        restart
+        do_status && do_stop || exit 0
+        do_start
         ;;
     status)
-        status -p $pidfile -l $(basename $lockfile) $NAME
+        do_status && echo $"$NAME is running" && exit 0 || echo $"$NAME is stopped" && exit 3
         ;;
     ping)
         $DAEMON ping || exit $?
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|force-reload|hardstop|condrestart|try-restart|status|ping}"
+        echo $"Usage: $0 {start|stop|restart|reload|force-reload|hardstop|condrestart|try-restart|status|ping}"
         exit 1
 esac
 


### PR DESCRIPTION
Changes needed for SuSE that were added:
- SuSE requires a different LSB-compliant init script from RHEL
- SuSE required a license header and a shell to be set in the specfile
- SuSE does not have selinux (yay) so I needed to make that conditional
- SuSE's LSB-compliant init script ended up being a mashup of RHEL's and Debian's init script, and was tested with 'service' and /etc/init.d/riak straight away.  The return codes matched [the LSB spec on the topic](http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html)
