### PR TITLE
Restart the old-fashioned way

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -56,10 +56,10 @@ This is the primary script for controlling the $SCRIPT node.
         "Node '$NAME_HOST' not responding to pings."
 
     restart
-        Stops and then starts the running $SCRIPT node without exiting the
-        Erlang VM.  Prints "ok" when successful.  When the node is already
-        stopped or not responding, prints:
-        "Node '$NAME_HOST' not responding to pings."
+        Stops and then starts the running $SCRIPT node. Prints "ok"
+        when successful.  When the node is already stopped or not
+        responding, prints: "Node '$NAME_HOST' not responding to
+        pings."
 
     console
         Starts the $SCRIPT node in the foreground, giving access to the Erlang
@@ -168,100 +168,101 @@ bootstrapd() {
     fi
 }
 
+do_start() {
+    # Make sure there is not already a node running
+    node_down_check
+
+    # Warn the user if ulimit is too low
+    check_ulimit
+
+    # Make sure log directory exists
+    mkdir -p $RUNNER_LOG_DIR
+
+    HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
+    export HEART_COMMAND
+    mkdir -p $PIPE_DIR
+    $ERTS_PATH/run_erl -daemon $PIPE_DIR/ $RUNNER_LOG_DIR \
+        "exec $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT console" 2>&1
+
+    if [ ! -z "$WAIT_FOR_PROCESS" ]; then
+        # Wait for the node to come up. We can't just ping it because
+        # distributed erlang comes up for a second before the node crashes
+        # (eg. in the case of an unwriteable disk). Once the node comes
+        # up we check for the $WAIT_FOR_PROCESS} process. If that's running
+        # then we assume things are good enough. This will at least let
+        # the user know when the node is crashing right after startup.
+        WAIT=${WAIT_FOR_ERLANG:-15}
+        while [ $WAIT -gt 0 ]; do
+            WAIT=`expr $WAIT - 1`
+            sleep 1
+
+            # squash stderr output to not frighten users if the node does not
+            # come up right away
+            MUTE=`ping_node 2> /dev/null`
+            if [ "$?" -ne 0 ]; then
+                continue
+            fi
+            PROCESS=`$NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
+            if [ "$PROCESS" != "undefined" ]; then
+                # Attempt to create a .pid file for the process
+                create_pid_file
+                exit 0
+            fi
+        done
+        echo "${SCRIPT} failed to start within ${WAIT_FOR_ERLANG:-15} seconds,"
+        echo "see the output of '${SCRIPT} console' for more information."
+        echo "If you want to wait longer, set the environment variable"
+        echo "WAIT_FOR_ERLANG to the number of seconds to wait."
+        exit 1
+    fi
+
+    # Attempt to create .pid file
+    create_pid_file
+}
+
+do_stop() {
+    get_pid
+    ES=$?
+    if [ "$ES" -ne 0 ] || [ -z $PID ]; then
+        exit $ES
+    fi
+
+    # Tell nodetool to stop
+    $NODETOOL stop
+    ES=$?
+    if [ "$ES" -ne 0 ]; then
+        exit $ES
+    fi
+
+    # Now wait for the app to *really* stop
+    while `kill -s 0 $PID 2>/dev/null`;
+    do
+        sleep 1
+    done
+
+    # remove pid file
+    rm -f $PID_FILE
+}
+
 # Check the first argument for instructions
 case "$1" in
     start)
         # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
         bootstrapd $@
-
-        # Make sure there is not already a node running
-        node_down_check
-
-        # Warn the user if ulimit is too low
-        check_ulimit
-
-        # Make sure log directory exists
-        mkdir -p $RUNNER_LOG_DIR
-
-        HEART_COMMAND="$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT start"
-        export HEART_COMMAND
-        mkdir -p $PIPE_DIR
-        $ERTS_PATH/run_erl -daemon $PIPE_DIR/ $RUNNER_LOG_DIR \
-            "exec $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT console" 2>&1
-
-        if [ ! -z "$WAIT_FOR_PROCESS" ]; then
-            # Wait for the node to come up. We can't just ping it because
-            # distributed erlang comes up for a second before the node crashes
-            # (eg. in the case of an unwriteable disk). Once the node comes
-            # up we check for the $WAIT_FOR_PROCESS} process. If that's running
-            # then we assume things are good enough. This will at least let
-            # the user know when the node is crashing right after startup.
-            WAIT=${WAIT_FOR_ERLANG:-15}
-            while [ $WAIT -gt 0 ]; do
-                WAIT=`expr $WAIT - 1`
-                sleep 1
-
-                # squash stderr output to not frighten users if the node does not
-                # come up right away
-                MUTE=`ping_node 2> /dev/null`
-                if [ "$?" -ne 0 ]; then
-                    continue
-                fi
-                PROCESS=`$NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
-                if [ "$PROCESS" != "undefined" ]; then
-                    # Attempt to create a .pid file for the process
-                    create_pid_file
-                    exit 0
-                fi
-            done
-            echo "${SCRIPT} failed to start within ${WAIT_FOR_ERLANG:-15} seconds,"
-            echo "see the output of '${SCRIPT} console' for more information."
-            echo "If you want to wait longer, set the environment variable"
-            echo "WAIT_FOR_ERLANG to the number of seconds to wait."
-            exit 1
-        fi
-
-        # Attempt to create .pid file
-        create_pid_file
+        do_start
         ;;
 
     stop)
         # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
         bootstrapd $@
-
-        get_pid
-        ES=$?
-        if [ "$ES" -ne 0 ] || [ -z $PID ]; then
-            exit $ES
-        fi
-
-        # Tell nodetool to stop
-        $NODETOOL stop
-        ES=$?
-        if [ "$ES" -ne 0 ]; then
-            exit $ES
-        fi
-
-        # Now wait for the app to *really* stop
-        while `kill -s 0 $PID 2>/dev/null`;
-        do
-            sleep 1
-        done
-
-        # remove pid file
-        rm -f $PID_FILE
+        do_stop
         ;;
 
     restart)
         # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
         bootstrapd $@
-
-        ## Restart the VM without exiting the process
-        $NODETOOL restart
-        ES=$?
-        if [ "$ES" -ne 0 ]; then
-            exit $ES
-        fi
+        do_stop
+        do_start
         ;;
 
     ping)


### PR DESCRIPTION
Related to #131, and per discussions with cliserv, `restart` isn't all that reliable. Here's a semantic change that may or may not be the way we want to proceed, but since I was in the mood to do something about it, here it be.

Worked "properly" (per the new semantic) in simple testing.

/cc @jaredmorrow @lukebakken 
