### PR TITLE
Prevent root ownership of Erlang cookie in platform data directory

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -133,6 +133,10 @@ fi
 
 # Ping node without stealing stdin
 ping_node() {
+    if [ "x$WHOAMI" = "xroot" ]; then
+        export HOME=/root
+    fi
+
     $NODETOOL ping < /dev/null
 }
 

--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -21,13 +21,6 @@ SCRIPTNAME=/etc/init.d/$NAME
 . /lib/init/vars.sh
 . /lib/lsb/init-functions
 
-# `service` strips all environmental VARS so
-# if no HOME was set in /etc/default/$NAME then set one here
-# to the data directory for erlexec's sake
-if [ -z "$HOME" ]; then
-    export HOME={{platform_data_dir}}
-fi
-
 #
 # Function that starts the daemon/service
 #

--- a/priv/templates/rpm/rhel.init.script
+++ b/priv/templates/rpm/rhel.init.script
@@ -29,13 +29,6 @@ pidfile=/var/run/$NAME/$NAME.pid
 # Read configuration variable file if it is present and readable
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 
-# `service` strips all environmental VARS so
-# if no HOME was set in /etc/sysconfig/$NAME then set one here
-# to the data directory for erlexec's sake
-if [ -z "$HOME" ]; then
-    export HOME={{platform_data_dir}}
-fi
-
 status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
 

--- a/priv/templates/rpm/suse.init.script
+++ b/priv/templates/rpm/suse.init.script
@@ -31,13 +31,6 @@ pidfile=/var/run/$NAME/$NAME.pid
 # Read configuration variable file if it is present and readable
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 
-# `service` strips all environmental VARS so
-# if no HOME was set in /etc/sysconfig/$NAME then set one here
-# to the data directory for erlexec's sake
-if [ -z "$HOME" ]; then
-    export HOME={{platform_data_dir}}
-fi
-
 # Checks the status of a node
 do_status() {
     $DAEMON ping >/dev/null 2>&1 && return 0 || return 3


### PR DESCRIPTION
The process for pinging a Riak node does not go through the bootstrap
procedure so that non-root users can easily detect if Riak is up/down.

When using the `service` command to manage the Riak service, any
subcommands to the Riak runner that make use of ping (AKA `ping_node()`)
can inadvertently create a root owned `.erlang.cookie` inside
`/var/lib/riak`. This causes problems when the Riak user attempts to read
the Erlang cookie later.

This change makes it so that if `ping_node()` gets called by root in any
way, the home directory is explicitly set to `/root`. That prevents future
issues around reading `/var/lib/riak/.erlang.cookie`.
### Basic tests

Can I start Riak with the `service` command:

``` bash
$ sudo service riak start
```

Can I ping Riak with the `service` command:

``` bash
$ sudo service riak ping
```

Can I ping Riak with a non-root user:

``` bash
$ riak ping
```
### Platforms to test
- [x] Ubuntu 12.04
- [x] Ubuntu 14.04
- [x] RHEL 6
- [ ] RHEL 5
- [ ] SUSE v?
