### PR TITLE
Require root or runner privs to run `ping` command

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -266,6 +266,8 @@ case "$1" in
         ;;
 
     ping)
+        # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
+        bootstrapd $@
         ## See if the VM is alive
         ping_node
         ES=$?


### PR DESCRIPTION
Addresses: basho/riak#561

In certain cases, if `riak ping` was run before `riak start` (or any
other command) a `.erlang.cookie` file was created with the wrong
privs (in this case a root user) that prevented the riak user from
starting erlang.
