### PR TITLE
Cleanup usage documentation for chkconfig

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -99,7 +99,8 @@ This is the primary script for controlling the $SCRIPT node.
         cannot be reached. Exit \`$SCRIPT attach-direct\` by pressing Ctrl-D.
 
     chkconfig
-        Confirms whether the app.config is valid.
+        Confirms whether the {{package_name}}.conf and advanced.config is
+        valid.
 
         For applications configured with cuttlefish, this includes a call
         to \`config generate\` also.

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -102,17 +102,17 @@ This is the primary script for controlling the $SCRIPT node.
         Confirms whether the app.config is valid.
 
         For applications configured with cuttlefish, this includes a call
-        to `config generate` also
+        to \`config generate\` also.
 
     config { generate | effective | describe VARIABLE } [-l debug]
         prints configuration information for applications configured with
-        cuttlefish enabled. `-l debug` outputs more information for
+        cuttlefish enabled. \`-l debug\` outputs more information for
         troubleshooting.
 
         generate
             generates the app.config and vm.args files from the .conf file.
             This is effectively what happens before start, but you'll need
-            to use `config generate -l debug` to see the cuttlefish debug
+            to use \`config generate -l debug\` to see the cuttlefish debug
             output.
 
         effective

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -99,7 +99,7 @@ This is the primary script for controlling the $SCRIPT node.
         cannot be reached. Exit \`$SCRIPT attach-direct\` by pressing Ctrl-D.
 
     chkconfig
-        Confirms whether the {{package_name}}.conf and advanced.config is
+        Confirms whether the $SCRIPT.conf and advanced.config is
         valid.
 
         For applications configured with cuttlefish, this includes a call


### PR DESCRIPTION
Usage documentation for the `chkconfig`, `config`, and `config generate` subcommands contained some unescaped backticks. Those unescaped characters were preventing the text within them from being visible.

In addition, I added explicit references to the configuration files (`{{package_name}}.conf` and `advanced.config`) inspected by the subcommands.

This pull request aims to resolve https://github.com/basho/node_package/issues/147.

/cc @macintux 
