### PR TITLE
Fix SmartOS runner patching after edits changed ordering

### DIFF
--- a/priv/templates/smartos/runner.patch
+++ b/priv/templates/smartos/runner.patch
@@ -1,33 +1,27 @@
-54a55
-> 
-57a59,64
+176,177c176,182
+<     # Warn the user if ulimit is too low
+<     check_ulimit
+---
+>     # Make sure we have access to enough file descriptors
+>     ULIMIT_S=$(prctl -n process.max-file-descriptor -t system -P $$ | awk '/max-file-descriptor/ { print $3 }')
+>     ULIMIT_H=$(prctl -n process.max-file-descriptor -t priv -P $$ | awk '/max-file-descriptor/ { print $3 }')
+>     if [ ${ULIMIT_S} -lt ${ULIMIT_H} ]; then
+>         echo "Trying to raise the file descriptor limit to maximum allowed."
+>         prctl -n process.max-file-descriptor -t system -v ${ULIMIT_H} $$ || true
+>     fi
+250a256,260
 >         if [ "${SMF_METHOD}" != "start" ]; then
 >             echo "***"
 >             echo "Warning: please use 'svcadm enable $SCRIPT' instead"
 >             echo "***"
 >         fi
-> 
-68,69c75,81
-<         # Warn the user if ulimit is too low
-<         check_ulimit
----
->         # Make sure we have access to enough file descriptors
->         ULIMIT_S=$(prctl -n process.max-file-descriptor -t system -P $$ | awk '/max-file-descriptor/ { print $3 }')
->         ULIMIT_H=$(prctl -n process.max-file-descriptor -t priv -P $$ | awk '/max-file-descriptor/ { print $3 }')
->         if [ ${ULIMIT_S} -lt ${ULIMIT_H} ]; then
->             echo "Trying to raise the file descriptor limit to maximum allowed."
->             prctl -n process.max-file-descriptor -t system -v ${ULIMIT_H} $$ || true
->         fi
-116a129
-> 
-119a133,138
+256a267,271
 >         if [ "${SMF_METHOD}" != "stop" ]; then
 >             echo "***"
 >             echo "Warning: please use 'svcadm disable $SCRIPT' instead"
 >             echo "***"
 >         fi
-> 
-226,227c245,251
+327,328c342,348
 <         # Warn the user if ulimit -n is less than the defined threshold
 <         check_ulimit
 ---


### PR DESCRIPTION
The node_package PR #143 changed the ordering in the runner script which broke the SmartOS patching of that script.  This PR simply fixes the patch.  I tested it on SmartOS 13.1 with `make package` and a successful patching step that once was broken.
