### PR TITLE
Change nodetool to permit zero parameter rpc calls

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -63,9 +63,30 @@ main(Args) ->
             io:format("~p\n", [rpc:call(TargetNode, init, restart, [], RpcTimeout)]);
         ["reboot"] ->
             io:format("~p\n", [rpc:call(TargetNode, init, reboot, [], RpcTimeout)]);
+        ["rpc", Module, Function] ->
+            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
+                          [], RpcTimeout) of
+                ok ->
+                    ok;
+                {badrpc, Reason} ->
+                    io:format(standard_error, "RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    halt(1);
+                _ ->
+                    halt(1)
+            end;
         ["rpc", Module, Function | RpcArgs] ->
             case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
                           [RpcArgs], RpcTimeout) of
+                ok ->
+                    ok;
+                {badrpc, Reason} ->
+                    io:format(standard_error, "RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    halt(1);
+                _ ->
+                    halt(1)
+            end;
+        ["rpc_infinity", Module, Function] ->
+            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function), [], infinity) of
                 ok ->
                     ok;
                 {badrpc, Reason} ->
@@ -167,13 +188,13 @@ chkconfig(File) ->
             io:format("ok\n"),
             halt(0);
         {error, {Line, Mod, Term}} ->
-            io:format(standard_error, 
-                      ["Error on line ", 
+            io:format(standard_error,
+                      ["Error on line ",
                        file:format_error({Line, Mod, Term}), "\n"], []),
             halt(1);
         {error, R} ->
             io:format(standard_error,
-                      ["Error reading config file: ", 
+                      ["Error reading config file: ",
                        file:format_error(R), "\n"], []),
             halt(1)
     end.


### PR DESCRIPTION
Change nodetool so that functions of zero arity may be called using
the supplied rpc facility. This is done by making a distinction
between the case when rpc parameters are present and when they are
not.

Previously calling zero arity functions has not been possible because
even submitting no rpc parameters is treated the same as submitting
the request with a single parameter of an empty list.  Nodetool
encapsulates any parameters as a list and the result of attempting to
call a function that takes no parameters was the rpc function calling
the supplied function with a single parameter of an empty list.

This change does not preclude calling functions with a single
parameter of an empty list. It just now makes that decision explicit
on the part of the caller.
