### PR TITLE
Revert "Merge branch 'feature/nodetool-zero-arg-rpc' into develop" [JIRA: TOOLS-130]

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -63,30 +63,9 @@ main(Args) ->
             io:format("~p\n", [rpc:call(TargetNode, init, restart, [], RpcTimeout)]);
         ["reboot"] ->
             io:format("~p\n", [rpc:call(TargetNode, init, reboot, [], RpcTimeout)]);
-        ["rpc", Module, Function] ->
-            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
-                          [], RpcTimeout) of
-                ok ->
-                    ok;
-                {badrpc, Reason} ->
-                    io:format(standard_error, "RPC to ~p failed: ~p\n", [TargetNode, Reason]),
-                    halt(1);
-                _ ->
-                    halt(1)
-            end;
         ["rpc", Module, Function | RpcArgs] ->
             case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
                           [RpcArgs], RpcTimeout) of
-                ok ->
-                    ok;
-                {badrpc, Reason} ->
-                    io:format(standard_error, "RPC to ~p failed: ~p\n", [TargetNode, Reason]),
-                    halt(1);
-                _ ->
-                    halt(1)
-            end;
-        ["rpc_infinity", Module, Function] ->
-            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function), [], infinity) of
                 ok ->
                     ok;
                 {badrpc, Reason} ->
@@ -188,13 +167,13 @@ chkconfig(File) ->
             io:format("ok\n"),
             halt(0);
         {error, {Line, Mod, Term}} ->
-            io:format(standard_error,
-                      ["Error on line ",
+            io:format(standard_error, 
+                      ["Error on line ", 
                        file:format_error({Line, Mod, Term}), "\n"], []),
             halt(1);
         {error, R} ->
             io:format(standard_error,
-                      ["Error reading config file: ",
+                      ["Error reading config file: ", 
                        file:format_error(R), "\n"], []),
             halt(1)
     end.


### PR DESCRIPTION
This reverts commit 93db72ef65d714e5e8d849fff558be3940992f2a, reversing
changes made to a56fe9b021e3543a24fdfc98f1c16704b41e62c6.

After looking more into this and thinking about what it would take to bring `riak-admin` up to speed to work in mixed cluster scenarios up until the point where people are no longer upgrading to some future version from 2.0 (_i.e._ a few years down the road) I am not sure it is worth the effort. This reverts the [previous](https://github.com/basho/node_package/pull/155) `node_package` change as the path of least resistance.
