### PR TITLE
Added a takes-time-to-stop warning to the stop command.

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -222,6 +222,9 @@ do_start() {
 }
 
 do_stop() {
+    # Note: We don't ship with a -shutdown_time vm argument in release
+    #       packages, so there's no hard ceiling.
+    echo "Gracefully stopping may take a few minutes."
     get_pid
     ES=$?
     if [ "$ES" -ne 0 ] || [ -z $PID ]; then


### PR DESCRIPTION
This is meant to address support requests coming from long shutdowns appearing to hang.
