### PR TITLE
Fixes for debian control template

### DIFF
--- a/priv/templates/deb/control
+++ b/priv/templates/deb/control
@@ -5,10 +5,12 @@ Maintainer: {{vendor_contact_name}} <{{vendor_contact_email}}>
 Build-Depends: debhelper (>= 7)
 Standards-Version: 3.9.3
 Homepage: {{vendor_url}}
-{{package_replacement_line}}
 
 Package: {{package_name}}
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, logrotate, sudo, {{deb_depends}}
+Homepage: {{vendor_url}}
 Description: {{package_shortdesc}}
   {{package_desc}}
+{{package_replacement_line}}
+{{package_conflicts_line}}

--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -6,6 +6,8 @@
              {package_install_user, "package_install_user"},
              {package_install_user_desc, "package_install_user_desc"},
              {package_install_group, "package_install_group"},
+             {package_replacement_line, "{{package_replacement_line_debian}}"},
+             {package_conflicts_line, "{{package_conflicts_line_debian}}"},
              {vendor_name, "vendor_name"},
              {vendor_url, "vendor_url"},
              {vendor_contact_name, "vendor_contact_name"},

--- a/priv/templates/deb/vars.config
+++ b/priv/templates/deb/vars.config
@@ -17,4 +17,5 @@
 {runner_lib_dir,     "{{platform_lib_dir}}"}.
 {runner_patch_dir,   "{{platform_lib_dir}}/{{package_patch_dir}}"}.
 {pipe_dir,           "/tmp/{{package_install_name}}/"}.
-{package_replacement_line,   "{{package_replacement_line_debian}}"}.
+{package_replacement_line, "{{package_replacement_line_debian}}"}.
+{package_conflicts_line, "{{package_replacement_line_debian}}"}.


### PR DESCRIPTION
Puts the `Replace:` and `Conflicts:` lines in the correct place
