### PR TITLE
Added kernel net_ticktime parameter

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -112,7 +112,7 @@ process_args(["-sname", TargetName | Rest], Acc, _) ->
     ThisNode = append_node_suffix(TargetName, "_maint_"),
     {ok, _} = net_kernel:start([ThisNode, shortnames]),
     process_args(Rest, Acc, nodename(TargetName));
-process_args(["-kernel","net_ticktime",TicktimeStr|Rest], Acc, TargetNode) ->
+process_args(["-kernel","net_ticktime", TicktimeStr | Rest], Acc, TargetNode) ->
     net_kernel:set_net_ticktime(list_to_integer(TicktimeStr)),
     process_args(Rest, Acc, TargetNode);
 process_args(["-rpctimeout", TimeoutStr | Rest], Acc, TargetNode) ->

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -112,6 +112,9 @@ process_args(["-sname", TargetName | Rest], Acc, _) ->
     ThisNode = append_node_suffix(TargetName, "_maint_"),
     {ok, _} = net_kernel:start([ThisNode, shortnames]),
     process_args(Rest, Acc, nodename(TargetName));
+process_args(["-kernel","net_ticktime",TicktimeStr|Rest], Acc, TargetNode) ->
+    net_kernel:set_net_ticktime(list_to_integer(TicktimeStr)),
+    process_args(Rest, Acc, TargetNode);
 process_args(["-rpctimeout", TimeoutStr | Rest], Acc, TargetNode) ->
     Timeout = case TimeoutStr of
                   "infinity" -> infinity;


### PR DESCRIPTION
It is possible to set the kernel net_ticktime in a Cuttlefish generated
vm.args file.  When set, there was no process_args fun to handle it
causing nodetool to fail to start.
