### PR TITLE
Allow custom name of the script + fix -sname in attach

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -17,6 +17,10 @@ unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as w
 
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}
+RUNNER_RELEASE={{runner_release}}
+if [ -z "$RUNNER_RELEASE" ]; then
+    RUNNER_RELEASE=$RUNNER_SCRIPT
+fi
 
 RUNNER_BASE_DIR={{runner_base_dir}}
 RUNNER_ETC_DIR={{runner_etc_dir}}

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -234,8 +234,8 @@ case "$1" in
         BINDIR=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/start.boot \
-            -config $RUNNER_BASE_DIR/releases/$APP_VSN/sys.config \
+        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_RELEASE.boot \
+            -config $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_RELEASE.config \
             -pa $RUNNER_PATCH_DIR \
             -args_file $RUNNER_ETC_DIR/vm.args -- ${1+"$@"}"
         export EMU

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -36,7 +36,7 @@ bootstrap() {
 }
 
 bootstrapd() {
-    # Create PID directory if it does not exist before dropping permissiongs
+    # Create PID directory if it does not exist before dropping permissions
     # to the runner user
     create_pid_dir
     ES=$?
@@ -188,7 +188,7 @@ case "$1" in
           node_up_check
         fi
 
-        echo "Direct Shell: Use \"Ctrl-D\" to quit. \"Ctrl-C\" will terminate the $SCRIPT node."
+        echo "Direct Shell: Use \"Ctrl-D\" to quit. \"Ctrl-C\" will terminate the $RUNNER_RELEASE node."
         shift
         exec $ERTS_PATH/to_erl $PIPE_DIR
         ;;
@@ -200,10 +200,10 @@ case "$1" in
         # Make sure a node is running
         node_up_check
 
-        echo "Remote Shell: Use \"Ctrl-C a\" to quit. q() or init:stop() will terminate the $SCRIPT node."
+        echo "Remote Shell: Use \"Ctrl-C a\" to quit. q() or init:stop() will terminate the $RUNNER_RELEASE node."
         shift
         NODE_NAME=${NAME_ARG#* }
-        exec $ERTS_PATH/erl -name c_$$_$NODE_NAME -hidden -remsh $NODE_NAME $COOKIE_ARG
+        exec $ERTS_PATH/erl $NAME_PARAM c_$$_$NODE_NAME -hidden -remsh $NODE_NAME $COOKIE_ARG
         ;;
 
     console)
@@ -234,7 +234,7 @@ case "$1" in
         BINDIR=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_SCRIPT \
+        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_RELEASE \
              -config $RUNNER_ETC_DIR/app.config \
             -pa $RUNNER_PATCH_DIR \
             -args_file $RUNNER_ETC_DIR/vm.args -- ${1+"$@"}"

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -5,7 +5,7 @@
 # installed by node_package (github.com/basho/node_package)
 
 # Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
+. "{{abs_node_root}}/bin/env.sh"
 
 
 # Keep track of where script was invoked
@@ -234,8 +234,8 @@ case "$1" in
         BINDIR=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$RUNNER_RELEASE \
-             -config $RUNNER_ETC_DIR/app.config \
+        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/start.boot \
+            -config $RUNNER_BASE_DIR/releases/$APP_VSN/sys.config \
             -pa $RUNNER_PATCH_DIR \
             -args_file $RUNNER_ETC_DIR/vm.args -- ${1+"$@"}"
         export EMU
@@ -296,7 +296,7 @@ case "$1" in
         ;;
 
     version)
-        echo $APP_VERSION
+        echo $APP_VSN
         ;;
 
     getpid)


### PR DESCRIPTION
Decouple the name of the script from the name of the release + allow -sname when attaching to the console.
