### PR TITLE
Set NODETOOL up as an alias and include ERL_FLAGS env vars

### DIFF
--- a/priv/base/runner
+++ b/priv/base/runner
@@ -203,7 +203,7 @@ do_start() {
             if [ "$?" -ne 0 ]; then
                 continue
             fi
-            PROCESS=`$NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
+            PROCESS=`NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
             if [ "$PROCESS" != "undefined" ]; then
                 # Attempt to create a .pid file for the process
                 create_pid_file
@@ -229,7 +229,7 @@ do_stop() {
     fi
 
     # Tell nodetool to stop
-    $NODETOOL stop
+    NODETOOL stop
     ES=$?
     if [ "$ES" -ne 0 ]; then
         exit $ES


### PR DESCRIPTION
nodetool won't work with TLS distribution as the erlang vm args
don't get passed in to escript. This commit reads the TLS args from
the vm.args file if it exists and prefixes the call to escript with
them.
The only way to have this work properly is to alias the command rather
than store it as a variable

basho/riak#509
