### PR TITLE
Log administrative stop, restart, reboot operations. [JIRA: RIAK-1872]

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -58,11 +58,23 @@ main(Args) ->
             %% a "pong"
             io:format("pong\n");
         ["stop"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, stop, [], RpcTimeout)]);
+            io:format("~p\n", [rpc:call(TargetNode, erlang, apply,
+                                        [fun() ->
+                                                 catch error_logger:info_msg("Administrative stop\n"),
+                                                 init:stop()
+                                         end, []], RpcTimeout)]);
         ["restart"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, restart, [], RpcTimeout)]);
+            io:format("~p\n", [rpc:call(TargetNode, erlang, apply,
+                                        [fun() ->
+                                                 catch error_logger:info_msg("Administrative restart\n"),
+                                                 init:restart()
+                                         end, []], RpcTimeout)]);
         ["reboot"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, reboot, [], RpcTimeout)]);
+            io:format("~p\n", [rpc:call(TargetNode, erlang, apply,
+                                        [fun() ->
+                                                 catch error_logger:info_msg("Administrative reboot\n"),
+                                                 init:reboot()
+                                         end, []], RpcTimeout)]);
         ["rpc", Module, Function | RpcArgs] ->
             case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
                           [RpcArgs], RpcTimeout) of


### PR DESCRIPTION
Useful for debugging situations when nodes are exiting gracefully (going through the application:stop sequence) but there are no log messages to explain why init:stop() was called (like top
level app supervisors dying).

With this change, error logger is used to record the administrative intent.

(If reviewing using Riak, you can't actually hit restart/reboot any more from the riak script, 
`erts-5.10.4/bin/escript /Users/jmeredith/basho/work/riak_ee-2.0/dev/dev2/bin/../erts-5.10.4/bin/nodetool -name dev2@127.0.0.1 -setcookie riak restart`
is your friend).
