### PR TITLE
Setting HOME env variable when unset due to downstream failures  [JIRA: TOOLS-138]

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -46,6 +46,13 @@ WAIT_FOR_PROCESS={{runner_wait_process}}
 
 WHOAMI=`whoami`
 
+# erlexec requires HOME to be set. The username needs to be a
+# unquoted literal because of the tilde expansion, hence the
+# usage of eval.
+if [ -z "$HOME" ]; then
+    export HOME=`eval echo "~$WHOAMI"`
+fi
+
 # Echo to stderr on errors
 echoerr() { echo "$@" 1>&2; }
 


### PR DESCRIPTION
Related issue here: https://github.com/basho/cuttlefish/issues/193

"erlexec requires the HOME variable to be set.

```
sargun@ubuntu:/tmp/mesos/slaves/20150712-141616-35725601-5050-4054-S0/frameworks/riak-mesos-go3/executors/test-cluster-c16260e2-21d0-44f3-9139-59b3b0a05948-2465/runs/latest$ unset HOME
sargun@ubuntu:/tmp/mesos/slaves/20150712-141616-35725601-5050-4054-S0/frameworks/riak-mesos-go3/executors/test-cluster-c16260e2-21d0-44f3-9139-59b3b0a05948-2465/runs/latest/riak/bin$ ./riak config generate -l debug
erlexec: HOME must be set
```

The way that this manifests itself during normal Riak startups, if $HOME isn't set:

```
=====
===== LOGGING STARTED Sun Jul 12 14:36:54 PDT 2015
=====
erlexec: HOME must be set
Error generating config with cuttlefish
  run `riak config generate -l debug` for more information.
```

Can we automatically set $HOME, if it's not set already?"

I've addressed this with the following addition to `env.sh`:

```
# erlexec requires HOME to be set. The username needs to be a
# unquoted literal because of the tilde expansion, hence the
# usage of eval.
if [ -z "$HOME" ]; then
    export HOME=`eval echo "~$WHOAMI"`
fi
```
