### PR TITLE
Replacing whoami with id -un to be more POSIX.2 compliant [JIRA: TOOLS-143]

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -44,7 +44,7 @@ fi
 # Registered process to wait for to consider start a success
 WAIT_FOR_PROCESS={{runner_wait_process}}
 
-WHOAMI=`whoami`
+WHOAMI=`id -un`
 
 # Echo to stderr on errors
 echoerr() { echo "$@" 1>&2; }


### PR DESCRIPTION
Per the suggestion in the comments from https://github.com/basho/node_package/pull/185, replacing the questionably supported `whoami` with `id -un` for collecting the current user for execution scripts.

Reference: http://pubs.opengroup.org/onlinepubs/007908799/xcu/id.html
