### PR TITLE
Review submitted PR [JIRA: TOOLS-139]

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -154,8 +154,13 @@ process_args([Arg | Rest], Acc, Opts) ->
 
 
 start_epmd() ->
-    [] = os:cmd(epmd_path() ++ " -daemon"),
-    ok.
+    case os:getenv("NO_EPMD") of
+      false ->
+        [] = os:cmd(epmd_path() ++ " -daemon"),
+        ok;
+      _ ->
+        ok
+    end.
 
 epmd_path() ->
     ErtsBinDir = filename:dirname(escript:script_name()),


### PR DESCRIPTION
We don't want to have nodetool start up the EPMd in certain environments, particularly where we'd modified disterl not to use stock EPMd.
