### PR TITLE
fix file ownership for tighter security [JIRA: TOOLS-232] [JIRA: RIAK-2381]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,4 +92,4 @@ setversion: varcheck
 ## Check required settings before continuing
 varcheck:
 	$(if $(PKG_VERSION),,$(error "Variable PKG_VERSION must be set and exported, see basho/node_package readme"))
-	$(if $(PKG_ID),,$(error "Variable PKK_ID must be set and exported, see basho/node_package readme"))
+	$(if $(PKG_ID),,$(error "Variable PKG_ID must be set and exported, see basho/node_package readme"))

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -26,9 +26,6 @@ for i in lib run log; do
     chown -R {{package_install_user}}:{{package_install_group}} /var/$i/{{package_install_name}}
 done
 
-chown -R {{package_install_user}}:{{package_install_group}} /usr/lib/{{package_install_name}}
-chown -R {{package_install_user}}:{{package_install_group}} /etc/{{package_install_name}}
-
 chmod 0755 /var/run/{{package_install_name}} /etc/{{package_install_name}}
 chmod 0644 /etc/{{package_install_name}}/*
 chmod -R +X /etc/{{package_install_name}}

--- a/priv/templates/fbsd/+DISPLAY
+++ b/priv/templates/fbsd/+DISPLAY
@@ -1,6 +1,6 @@
 Thank you for installing {{package_name}}.
 
-{{package_name}} has been installed in /usr/local owned by user:group {{package_install_user}}:{{package_install_group}}
+{{package_name}} has been installed in /usr/local owned by user:group root:wheel
 
 The primary directories are:
 

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -88,21 +88,18 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	@echo "Packaging /usr/local files"
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@cwd /usr/local" >> +CONTENTS && \
-	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
-	   echo "@group {{package_install_group}}" >> +CONTENTS && \
-	   echo "@mode 0755" >> +CONTENTS
+	   echo "@owner root" >> +CONTENTS && \
+	   echo "@group wheel" >> +CONTENTS && \
+	   echo "@mode 0755" >> +CONTENT
 	cd $(BUILD_STAGE_DIR) && \
 	   find lib -type f >> +CONTENTS && \
 	   find lib -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_base_dir}}" >> +CONTENTS
+	   echo "@exec chown -R root:wheel {{platform_base_dir}}" >> +CONTENTS && \
+	   find {{bin_or_sbin}} -type f >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
-	   echo "@owner root" >> +CONTENTS && \
-	   echo "@group wheel" >> +CONTENTS && \
 	   echo "@mode 0644" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS && \
-	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS && \
-	   echo "@mode 0755" >> +CONTENTS && \
-	   find {{bin_or_sbin}} -type f >> +CONTENTS
+	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS
 	@echo "Packaging /var files"
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@cwd /var" >> +CONTENTS

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -57,7 +57,7 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	echo "@name {{package_name}}-$(PKG_VERSION)" >> plist
 	echo "@conflicts {{package_name}}-*" >> plist
 	echo "@exec if ! pw groupshow {{package_install_group}} 2>/dev/null; then pw groupadd {{package_install_group}}; fi" >> plist
-	echo "@exec if ! pw usershow {{package_install_user}} 2>/dev/null; then pw useradd {{package_install_user}} -g {{package_install_group}} -h - -d {{platform_base_dir}} -s /bin/sh -c \"{{package_install_user_desc}}\"; fi" >> plist
+	echo "@exec if ! pw usershow {{package_install_user}} 2>/dev/null; then pw useradd {{package_install_user}} -g {{package_install_group}} -h - -d {{platform_data_dir}} -s /bin/sh -c \"{{package_install_user_desc}}\"; fi" >> plist
 	echo "@comment ORIGIN:{{freebsd_package_category}}/{{package_install_name}}" >> plist
 
 	@echo "Copying Man pages to staging directory"

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -73,9 +73,9 @@ packing_list_files: $(BUILD_STAGE_DIR)
 		{{/package_commands}} echo -n; fi
 
 	@echo "Scanning data and log directories for empty directories to add"
-	$(eval DIRS_INSTALL = {{platform_log_dir}})
-	$(eval DIRS_INSTALL += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
-	for i in $(DIRS_INSTALL); \
+	$(eval PACKAGE_USER_WRITABLE_DIRS = {{platform_log_dir}})
+	$(eval PACKAGE_USER_WRITABLE_DIRS += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
+	for i in $(PACKAGE_USER_WRITABLE_DIRS); \
 	    do                          \
 		echo "@exec mkdir -p $$i" >> plist; \
                 echo "@exec chown -R {{package_install_user}}:{{package_install_group}} $$i" >> plist; \

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -92,8 +92,6 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	   echo "@group {{package_install_group}}" >> +CONTENTS && \
 	   echo "@mode 0755" >> +CONTENTS
 	cd $(BUILD_STAGE_DIR) && \
-	   find {{bin_or_sbin}} -type f >> +CONTENTS
-	cd $(BUILD_STAGE_DIR) && \
 	   find lib -type f >> +CONTENTS && \
 	   find lib -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS && \
 	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_base_dir}}" >> +CONTENTS
@@ -102,8 +100,9 @@ packing_list_files: $(BUILD_STAGE_DIR)
 	   echo "@group wheel" >> +CONTENTS && \
 	   echo "@mode 0644" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS && \
-	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS
-
+	   find etc -d -type d -mindepth 1 -exec echo "@dirrm {}" \; >> +CONTENTS && \
+	   echo "@mode 0755" >> +CONTENTS && \
+	   find {{bin_or_sbin}} -type f >> +CONTENTS
 	@echo "Packaging /var files"
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@cwd /var" >> +CONTENTS

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -172,12 +172,12 @@ exit 0
 %{_libdir}/*
 %dir %{_sysconfdir}/{{package_install_name}}
 %config(noreplace) %{_sysconfdir}/{{package_install_name}}/*
-%{_{{bin_or_sbin}}dir}/*
 %{_localstatedir}/lib/{{package_install_name}}
 %{_localstatedir}/log/{{package_install_name}}
 %{_localstatedir}/run/{{package_install_name}}
 %defattr(-,root,root)
 %{_sysconfdir}/init.d/{{package_install_name}}
+%{_{{bin_or_sbin}}dir}/*
 
 %clean
 rm -rf %{buildroot}

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -114,7 +114,7 @@ cp -R %{relpath}/data/* \
       %{buildroot}%{_localstatedir}/lib/{{package_install_name}}
 
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m755 %{_topdir}/init.script  %{buildroot}%{_sysconfdir}/init.d/{{package_install_name}}
+install -u root -g root -m755 %{_topdir}/init.script  %{buildroot}%{_sysconfdir}/init.d/{{package_install_name}}
 
 # Needed to work around check-rpaths which seems to be hardcoded into recent
 # RPM releases

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -114,7 +114,7 @@ cp -R %{relpath}/data/* \
       %{buildroot}%{_localstatedir}/lib/{{package_install_name}}
 
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -u root -g root -m755 %{_topdir}/init.script  %{buildroot}%{_sysconfdir}/init.d/{{package_install_name}}
+install -m755 %{_topdir}/init.script  %{buildroot}%{_sysconfdir}/init.d/{{package_install_name}}
 
 # Needed to work around check-rpaths which seems to be hardcoded into recent
 # RPM releases
@@ -176,6 +176,7 @@ exit 0
 %{_localstatedir}/lib/{{package_install_name}}
 %{_localstatedir}/log/{{package_install_name}}
 %{_localstatedir}/run/{{package_install_name}}
+%defattr(-,root,root)
 %{_sysconfdir}/init.d/{{package_install_name}}
 
 %clean

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -169,15 +169,15 @@ exit 0
 # Man pages are optional and might be missing, read from file
 %files -f additional_files_list
 %defattr(-,{{package_install_user}},{{package_install_group}})
-%{_libdir}/*
-%dir %{_sysconfdir}/{{package_install_name}}
-%config(noreplace) %{_sysconfdir}/{{package_install_name}}/*
 %{_localstatedir}/lib/{{package_install_name}}
 %{_localstatedir}/log/{{package_install_name}}
 %{_localstatedir}/run/{{package_install_name}}
 %defattr(-,root,root)
 %{_sysconfdir}/init.d/{{package_install_name}}
 %{_{{bin_or_sbin}}dir}/*
+%{_libdir}/*
+%dir %{_sysconfdir}/{{package_install_name}}
+%config(noreplace) %{_sysconfdir}/{{package_install_name}}/*
 
 %clean
 rm -rf %{buildroot}

--- a/priv/templates/smartos/+DISPLAY
+++ b/priv/templates/smartos/+DISPLAY
@@ -1,6 +1,6 @@
 Thank you for installing {{package_name}}.
 
-{{package_name}} has been installed in {{platform_base_dir}} owned by user:group {{package_install_user}}:{{package_install_group}}
+{{package_name}} has been installed in {{platform_base_dir}} owned by user:group root:root
 
 The primary directories are:
 

--- a/priv/templates/smartos/+INSTALL
+++ b/priv/templates/smartos/+INSTALL
@@ -68,7 +68,7 @@ if [ "$2" = "POST-INSTALL" ]; then
     # This shouldn't have to happen in the post-install, but
     # there is some non-deterministic stuff happening during
     # install on SmartOS that causes wrong ownership.
-    chown -R root:root {{platform_etc_dir}}
+    chown -R root:{{package_install_group}} {{platform_etc_dir}}
 
     for i in $CONFIG_FILES; do
         if [ -f {{platform_etc_dir}}/$i ]; then

--- a/priv/templates/smartos/+INSTALL
+++ b/priv/templates/smartos/+INSTALL
@@ -86,8 +86,12 @@ if [ "$2" = "POST-INSTALL" ]; then
         -c "{{package_install_name}} default project" {{package_install_name}}
     fi
 
+    # Ensure proper permissions of SMF files
+    chown -R root:root /opt/local/share/smf/{{package_install_name}}
+    chown -R root:root /opt/local/share/smf/{{package_install_name}}-epmd
+    chmod 755 /opt/local/share/smf/{{package_install_name}}-epmd/{{package_install_name}}-epmd
+
     # Import SMF definitions
     svccfg import /opt/local/share/smf/{{package_install_name}}-epmd/manifest.xml
-    chmod 755 /opt/local/share/smf/{{package_install_name}}-epmd/{{package_install_name}}-epmd
     svccfg import /opt/local/share/smf/{{package_install_name}}/manifest.xml
 fi

--- a/priv/templates/smartos/+INSTALL
+++ b/priv/templates/smartos/+INSTALL
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Variable that will get replaced by the Makefile dirs_create target
-CREATE_DIRS="%DIRS_CREATE%"
+PACKAGE_USER_WRITABLE_DIRS="%PACKAGE_USER_WRITABLE_DIRS%"
 
 # Config files that could possibly be installed
 CONFIG_FILES="vm.args app.config advanced.config {{cuttlefish_conf}}"
@@ -12,12 +12,12 @@ if [ "$2" = "PRE-INSTALL" ]; then
     fi
 
     if ! getent passwd "{{package_install_user}}" 2>/dev/null 1>&2; then
-        useradd -g {{package_install_group}} -d {{platform_base_dir}} -s /bin/sh {{package_install_user}}
+        useradd -g {{package_install_group}} -d {{platform_data_dir}} -s /bin/sh {{package_install_user}}
     fi
 
     # Create var directories outside of +CONTENTS
-    # Read directories from the CREATE_DIRS variable
-    for i in $CREATE_DIRS; do
+    # Read directories from the PACKAGE_USER_WRITABLE_DIRS variable
+    for i in $PACKAGE_USER_WRITABLE_DIRS; do
         if [ -d $i ]; then
             echo "Skipping directory creation of $i, directory already exists"
         else
@@ -42,12 +42,12 @@ if [ "$2" = "POST-INSTALL" ]; then
 
     # Ensure proper permissions on {{package_name}} scripts
     for i in {{#package_commands}}{{name}} {{/package_commands}}; do
-        chown {{package_install_user}}:{{package_install_group}} {{platform_bin_dir}}/$i
+        chown root:root {{platform_bin_dir}}/$i
         chmod 755 {{platform_bin_dir}}/$i
     done
 
     # Ensure proper ownership of lib directory
-    chown -R {{package_install_user}}:{{package_install_group}} {{platform_lib_dir}}
+    chown -R root:root {{platform_lib_dir}}
     chmod -R g+r {{platform_lib_dir}}
 
     # Treat new configuration files as new if old ones already exist
@@ -68,7 +68,7 @@ if [ "$2" = "POST-INSTALL" ]; then
     # This shouldn't have to happen in the post-install, but
     # there is some non-deterministic stuff happening during
     # install on SmartOS that causes wrong ownership.
-    chown -R root:{{package_install_group}} {{platform_etc_dir}}
+    chown -R root:root {{platform_etc_dir}}
 
     for i in $CONFIG_FILES; do
         if [ -f {{platform_etc_dir}}/$i ]; then

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -133,7 +133,7 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@comment Packing /opt/local/etc files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
-	   echo "@group riak" >> +CONTENTS && \
+	   echo "@group {{package_install_user}}" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -133,7 +133,7 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@comment Packing /opt/local/etc files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
-	   echo "@group root" >> +CONTENTS && \
+	   echo "@group riak" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -127,29 +127,29 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 	   echo "@comment Packing /opt/local/etc files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
 	   echo "@owner root" >> +CONTENTS && \
-	   echo "@group {{package_install_user}}" >> +CONTENTS && \
+	   echo "@group root" >> +CONTENTS && \
 	   find etc -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@comment Packing lib files" >> +CONTENTS && \
 	   echo "@cwd /opt/local" >> +CONTENTS && \
-	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
-	   echo "@group {{package_install_group}}" >> +CONTENTS
+	   echo "@owner root" >> +CONTENTS && \
+	   echo "@group root" >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   find lib -type f >> +CONTENTS && \
-	   echo "@exec chown -R {{package_install_user}}:{{package_install_group}} {{platform_base_dir}}" >> +CONTENTS
+	   echo "@exec chown -R root:root {{platform_base_dir}}" >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
 	   echo "@comment Packing /usr/local {{bin_or_sbin}} files" >> +CONTENTS && \
-	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
-	   echo "@group {{package_install_group}}" >> +CONTENTS && \
+	   echo "@owner root" >> +CONTENTS && \
+	   echo "@group root" >> +CONTENTS && \
 	   echo "@mode 0755" >> +CONTENTS && \
 	   find {{bin_or_sbin}} -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
-	   echo "@owner {{package_install_user}}" >> +CONTENTS && \
-	   echo "@group {{package_install_group}}" >> +CONTENTS && \
+	   echo "@owner root" >> +CONTENTS && \
+	   echo "@group root" >> +CONTENTS && \
 	   find share -type f >> +CONTENTS
 
 	cd $(BUILD_STAGE_DIR) && \
@@ -167,13 +167,13 @@ packing_list_files: $(BUILD_STAGE_DIR) templates
 # I feel dirty now.
 dirs_file: $(BUILD_STAGE_DIR)
 	@echo "Adding data and log directories to directory list"
-	$(eval DIRS_INSTALL = {{platform_data_dir}})
-	$(eval DIRS_INSTALL += {{platform_log_dir}})
+	$(eval PACKAGE_USER_WRITABLE_DIRS = {{platform_data_dir}})
+	$(eval PACKAGE_USER_WRITABLE_DIRS += {{platform_log_dir}})
 	@echo "Scanning var directory for any additional install paths"
-	$(eval DIRS_INSTALL += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
+	$(eval PACKAGE_USER_WRITABLE_DIRS += $(shell cd $(BUILD_STAGE_DIR) && find $(PDATA_ROOT_DIR) -type d -exec printf "/%s " {} \;))
 	cd $(BUILD_STAGE_DIR) && \
 	   cp +INSTALL +INSTALL.tmp && \
-	   sed -e 's|%DIRS_CREATE%|${DIRS_INSTALL}|' < \
+	   sed -e 's|%PACKAGE_USER_WRITABLE_DIRS%|${PACKAGE_USER_WRITABLE_DIRS}|' < \
 	       +INSTALL.tmp > +INSTALL && \
 	   rm +INSTALL.tmp
 

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -42,6 +42,12 @@ OPENSSL_DEP = openssl-1.0.1*
 GCC_DEP     = gcc47-libs>=4.7.0
 SMF_MANIFEST = manifest131.xml
 endif
+ifeq ($(PKGSRC_VERSION),2015Q4)  # SmartOS 15.4.0
+NCURSES_DEP = ncurses-6*
+OPENSSL_DEP = openssl-1.0.2*
+GCC_DEP     = gcc49-libs>=4.9.3
+SMF_MANIFEST = manifest154.xml
+endif
 
 
 # Where we install things (based on vars.config)

--- a/priv/templates/smartos/manifest131.xml
+++ b/priv/templates/smartos/manifest131.xml
@@ -16,7 +16,7 @@
     <method_context working_directory="/tmp" project="{{package_install_name}}">
       <method_credential user="{{package_install_user}}" group="{{package_install_group}}" />
       <method_environment>
-        <envvar name="HOME" value="{{platform_base_dir}}" />
+        <envvar name="HOME" value="{{platform_data_dir}}" />
         <envvar name="LOGNAME" value="{{package_install_user}}" />
         <envvar name="PATH" value="/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin" />
         <envvar name="LD_PRELOAD_32" value="/lib/libumem.so.1" />

--- a/priv/templates/smartos/manifest154.xml
+++ b/priv/templates/smartos/manifest154.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="{{package_install_name}}">
+  <service name="application/{{package_install_name}}" type="service" version="1">
+    <create_default_instance enabled="false" />
+    <single_instance />
+    <dependency name="network" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+    <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+    <dependency name="{{package_install_name}}-epmd" grouping="require_all" restart_on="error" type="service">
+      <service_fmri value="svc:/network/{{package_install_name}}-epmd:default" />
+    </dependency>
+    <method_context working_directory="/tmp" project="{{package_install_name}}">
+      <method_credential user="{{package_install_user}}" group="{{package_install_group}}" />
+      <method_environment>
+        <envvar name="HOME" value="{{platform_data_dir}}" />
+        <envvar name="LOGNAME" value="{{package_install_user}}" />
+        <envvar name="PATH" value="/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin" />
+        <envvar name="LD_PRELOAD_32" value="/lib/libumem.so.1" />
+        <envvar name="LD_PRELOAD_64" value="/lib/amd64/libumem.so.1:/opt/local/gcc47/x86_64-sun-solaris2.11/lib/amd64/libgcc_s.so.1"/>
+        <envvar name="UMEM_OPTIONS" value="allocator=best" />
+      </method_environment>
+    </method_context>
+    <exec_method type="method" name="start" exec="{{platform_bin_dir}}/{{package_install_name}} start" timeout_seconds="60" />
+    <exec_method type="method" name="stop" exec="{{platform_bin_dir}}/{{package_install_name}} stop" timeout_seconds="60" />
+    <exec_method type="method" name="restart" exec="{{platform_bin_dir}}/{{package_install_name}} restart" timeout_seconds="60" />
+    <stability value="Stable" />
+    <template>
+      <common_name>
+        <loctext xml:lang="C">{{package_shortdesc}}</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>

--- a/priv/templates/smartos/smartos.template
+++ b/priv/templates/smartos/smartos.template
@@ -30,5 +30,6 @@
 {template, "manifest16.xml", "manifest16.xml"}.
 {template, "manifest18.xml", "manifest18.xml"}.
 {template, "manifest131.xml", "manifest131.xml"}.
+{template, "manifest154.xml", "manifest154.xml"}.
 {template, "epmd", "epmd"}.
 {template, "runner.patch", "runner.patch"}.

--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -50,7 +50,9 @@ prototype:
 	echo "i r.preserve" >> prototype
 	echo '' >> prototype
 	pkgproto rel/{{package_install_name}}={{package_install_name}} >> prototype
-	sed -e "s/ $(LOGNAME) .*$$/ {{package_install_user}} {{package_install_group}}/" \
+	sed -e "s/ $(LOGNAME) .*$$/ root bin/" \
+		-e "s/d none {{package_install_name}}\/data \(.*\) $(LOGNAME) \(.*\)/d none {{package_install_name}}\/data \1 {{package_install_user}} {{package_install_group}}/" \
+		-e "s/d none {{package_install_name}}\/log \(.*\) $(LOGNAME) \(.*\)/d none {{package_install_name}}\/log \1 {{package_install_user}} {{package_install_group}}/" \
 	    -e 's/f none {{package_install_name}}\/etc/e preserve {{package_install_name}}\/etc/' prototype > prototype.tmp && mv prototype.tmp prototype
 
 $(PKGERDIR)/pkgclean:

--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -51,8 +51,8 @@ prototype:
 	echo '' >> prototype
 	pkgproto rel/{{package_install_name}}={{package_install_name}} >> prototype
 	sed -e "s/ $(LOGNAME) .*$$/ root bin/" \
-		-e "s/d none {{package_install_name}}\/data \(.*\) $(LOGNAME) \(.*\)/d none {{package_install_name}}\/data \1 {{package_install_user}} {{package_install_group}}/" \
-		-e "s/d none {{package_install_name}}\/log \(.*\) $(LOGNAME) \(.*\)/d none {{package_install_name}}\/log \1 {{package_install_user}} {{package_install_group}}/" \
+		-e "s/\([f|d]\) none {{package_install_name}}\/log\(.*\) \(.*\) root bin/\1 none {{package_install_name}}\/log\2 \3 {{package_install_user}} {{package_install_group}}/" \
+		-e "s/\([f|d]\) none {{package_install_name}}\/data\(.*\) \(.*\) root bin/\1 none {{package_install_name}}\/data\2 \3 {{package_install_user}} {{package_install_group}}/" \
 	    -e 's/f none {{package_install_name}}\/etc/e preserve {{package_install_name}}\/etc/' prototype > prototype.tmp && mv prototype.tmp prototype
 
 $(PKGERDIR)/pkgclean:

--- a/priv/templates/solaris/preinstall
+++ b/priv/templates/solaris/preinstall
@@ -9,7 +9,7 @@ fi
 # create {{package_install_user}} user only if it doesn't already exist
 getent passwd {{package_install_user}} >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-        useradd -g {{package_install_group}} -d /opt/{{package_install_name}} -s /usr/bin/ksh {{package_install_user}}
+        useradd -g {{package_install_group}} -d {{platform_data_dir}} -s /usr/bin/ksh {{package_install_user}}
         usermod -c "{{package_install_user_desc}}" {{package_install_user}}
 fi
 


### PR DESCRIPTION
Need to audit file ownership across packages in general - follow conventions of other packages and install as few things as possible as riak:riak (since most systems install executables/libraries as root:root or root:wheel)

Specific issues found:

init.d script in RPM should be owned by root:root not riak:riak - can create a potential security issue.
As a workaround, you should ensure that your init.d scripts are owned by root:root not riak:riak.

on FreeBSD systems using older pkg_add (vs. pkgng) /usr/local/sbin/_riak_ should be owned by root:wheel rather than {{package_install_user}}:{{package_install_group}}

Many installers install most/all of the riak binaries/libraries as riak:riak - change to root:wheel, root:bin, or root:root where appropriate
- For each OS, build package, install, check permissions on all files (especially executables). Only riak-writable files should be data/log directories, and the home directory of the riak user, as the `.erlang.cookie` file is written wherever the `riak` user's home directory is. There were several packages that had set it to be {{platform_base_dir}} rather than {{platform_data_dir}}, and {{platform_base_dir}} really should not be writable to the service user. Make sure that any configuration files are readable by riak - in a few cases, this means group `riak` with appropriate (640) permissions - in others, the default is to install 644 so the files are world-readable. Not changing this for now.
- run `riak start` and make sure it starts cleanly.
- run `riak-admin ping`
- run `riak-admin test` to make sure you can actually write/read data
- run `riak-admin attach-direct`

Todo list for testing:
- [x] FreeBSD 9
- [x] FreeBSD 10
- [x] One RPM-based system (Centos 7)
- [x] One deb-based system (Ubuntu 14)
- [x] SmartOS (tested latest)
- [x] Solaris (tested 11)
