### PR TITLE
Force correct permissions on Debian package files in /usr/lib/

### DIFF
--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -30,7 +30,9 @@ chmod 0755 /var/run/{{package_install_name}} /etc/{{package_install_name}}
 chmod 0644 /etc/{{package_install_name}}/*
 chmod -R +X /etc/{{package_install_name}}
 chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
+chmod 0755 /usr/lib/{{package_install_name}}/lib/app_epath.sh
 chmod 0755 /usr/lib/{{package_install_name}}/erts-*/bin/nodetool
+chmod -R go+r /usr/lib/{{package_install_name}}/lib/
 
 case "$1" in
     configure)

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -32,7 +32,7 @@ chmod -R +X /etc/{{package_install_name}}
 chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
 chmod 0755 /usr/lib/{{package_install_name}}/lib/app_epath.sh
 chmod 0755 /usr/lib/{{package_install_name}}/erts-*/bin/nodetool
-chmod -R go+r /usr/lib/{{package_install_name}}/lib/
+chmod -R go+rX /usr/lib/{{package_install_name}}/lib/
 
 case "$1" in
     configure)

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -27,8 +27,7 @@ for i in lib run log; do
 done
 
 chmod 0755 /var/run/{{package_install_name}} /etc/{{package_install_name}}
-chmod 0644 /etc/{{package_install_name}}/*
-chmod -R +X /etc/{{package_install_name}}
+chmod -R a+rX /etc/{{package_install_name}}
 chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
 chmod 0755 /usr/lib/{{package_install_name}}/lib/app_epath.sh
 chmod 0755 /usr/lib/{{package_install_name}}/erts-*/bin/nodetool


### PR DESCRIPTION
One of our build machines was set up differently from the VM we used to test the recent permissions fixes, and it ended up creating a package with some files set to 600 and 700 because of the permissions on the directory it used to do the build. This fix should prevent such issues from happening again in the future, as it explicitly forces correct permissions on the affected files, regardless of what permissions those files happened to be created with at build time.
