### PR TITLE
deb template cleanup + systemd support

### DIFF
--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -36,5 +36,5 @@
 {template, "postrm", "postrm"}.
 {template, "rules", "rules"}.
 {template, "vars.config", "vars.config"}.
-{template, "init.script", "init.script"}.
+{template, "init.script", "{{package_name}}.{{package_install_name}}.init"}.
 {template, "package.manpages", "{{package_name}}.manpages"}.

--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -31,6 +31,7 @@
 {template, "control", "control"}.
 {template, "copyright", "copyright"}.
 {template, "dirs", "dirs"}.
+{template, "install", "install"}.
 {template, "postinst", "postinst"}.
 {template, "postrm", "postrm"}.
 {template, "rules", "rules"}.

--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -37,3 +37,4 @@
 {template, "rules", "rules"}.
 {template, "vars.config", "vars.config"}.
 {template, "init.script", "init.script"}.
+{template, "package.manpages", "{{package_name}}.manpages"}.

--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -37,4 +37,5 @@
 {template, "rules", "rules"}.
 {template, "vars.config", "vars.config"}.
 {template, "init.script", "{{package_name}}.{{package_install_name}}.init"}.
+{template, "package.service", "{{package_name}}.{{package_install_name}}.service"}.
 {template, "package.manpages", "{{package_name}}.manpages"}.

--- a/priv/templates/deb/dirs
+++ b/priv/templates/deb/dirs
@@ -1,4 +1,3 @@
-etc/init.d
 etc/logrotate.d
 var/run/{{package_install_name}}
 var/log/{{package_install_name}}

--- a/priv/templates/deb/dirs
+++ b/priv/templates/deb/dirs
@@ -1,3 +1,2 @@
 etc/logrotate.d
-var/run/{{package_install_name}}
 var/log/{{package_install_name}}

--- a/priv/templates/deb/dirs
+++ b/priv/templates/deb/dirs
@@ -1,9 +1,5 @@
 etc/init.d
-etc/{{package_install_name}}
 etc/logrotate.d
-usr/lib/{{package_install_name}}
-usr/{{bin_or_sbin}}
 usr/share/man/man1
 var/run/{{package_install_name}}
-var/lib/{{package_install_name}}
 var/log/{{package_install_name}}

--- a/priv/templates/deb/dirs
+++ b/priv/templates/deb/dirs
@@ -1,5 +1,4 @@
 etc/init.d
 etc/logrotate.d
-usr/share/man/man1
 var/run/{{package_install_name}}
 var/log/{{package_install_name}}

--- a/priv/templates/deb/init.script
+++ b/priv/templates/deb/init.script
@@ -12,6 +12,7 @@
 NAME={{package_install_name}}
 DAEMON=/usr/{{bin_or_sbin}}/$NAME
 SCRIPTNAME=/etc/init.d/$NAME
+RUNDIR=/var/run/$NAME
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
@@ -32,6 +33,10 @@ fi
 #
 do_start()
 {
+    if [ ! -d $RUNDIR ]; then
+        mkdir $RUNDIR
+        chown {{package_install_user}}:{{package_install_group}} $RUNDIR
+    fi
     # Return
     #   0 if daemon has been started
     #   1 if daemon was already running

--- a/priv/templates/deb/install
+++ b/priv/templates/deb/install
@@ -1,0 +1,10 @@
+rel/{{package_install_name}}/lib usr/lib/{{package_install_name}}
+rel/{{package_install_name}}/erts* usr/lib/{{package_install_name}}
+rel/{{package_install_name}}/releases usr/lib/{{package_install_name}}
+
+{{#package_commands}}
+rel/{{package_install_name}}/bin/{{name}} usr/{{bin_or_sbin}}
+{{/package_commands}}
+
+rel/{{package_install_name}}/etc/* etc/{{package_install_name}}
+rel/{{package_install_name}}/data/* var/lib/{{package_install_name}}

--- a/priv/templates/deb/package.manpages
+++ b/priv/templates/deb/package.manpages
@@ -1,0 +1,1 @@
+doc/man/man1/*.1.gz

--- a/priv/templates/deb/package.service
+++ b/priv/templates/deb/package.service
@@ -1,0 +1,14 @@
+[Unit]
+Description={{package_shortdesc}}
+
+[Service]
+ExecStart=/usr/{{bin_or_sbin}}/{{package_install_name}} start
+ExecStop=/usr/{{bin_or_sbin}}/{{package_install_name}} stop
+User={{package_install_user}}
+Type=forking
+PIDFile=/var/run/{{package_install_name}}/{{package_install_name}}.pid
+EnvironmentFile=-/etc/default/{{package_install_name}}
+RuntimeDirectory={{package_install_name}}
+
+[Install]
+WantedBy=multi-user.target

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -23,13 +23,6 @@ for i in lib log; do
     chown -R {{package_install_user}}:{{package_install_group}} /var/$i/{{package_install_name}}
 done
 
-chmod 0755 /etc/{{package_install_name}}
-chmod -R a+rX /etc/{{package_install_name}}
-chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
-chmod 0755 /usr/lib/{{package_install_name}}/lib/app_epath.sh
-chmod 0755 /usr/lib/{{package_install_name}}/erts-*/bin/nodetool
-chmod -R go+rX /usr/lib/{{package_install_name}}/lib/
-
 case "$1" in
     configure)
     ;;

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -19,11 +19,11 @@ if ! getent passwd {{package_install_user}} >/dev/null; then
                 --gecos "{{package_install_user_desc}}" {{package_install_user}}
 fi
 
-for i in lib run log; do
+for i in lib log; do
     chown -R {{package_install_user}}:{{package_install_group}} /var/$i/{{package_install_name}}
 done
 
-chmod 0755 /var/run/{{package_install_name}} /etc/{{package_install_name}}
+chmod 0755 /etc/{{package_install_name}}
 chmod -R a+rX /etc/{{package_install_name}}
 chmod 0755 /usr/lib/{{package_install_name}}/lib/env.sh
 chmod 0755 /usr/lib/{{package_install_name}}/lib/app_epath.sh

--- a/priv/templates/deb/postinst
+++ b/priv/templates/deb/postinst
@@ -5,9 +5,6 @@
 
 set -e
 
-# install startup script
-update-rc.d {{package_install_name}} defaults >/dev/null
-
 # create group
 if ! getent group {{package_install_group}} >/dev/null; then
         addgroup --system {{package_install_group}}

--- a/priv/templates/deb/postrm
+++ b/priv/templates/deb/postrm
@@ -22,10 +22,6 @@ set -e
 case "$1" in
     purge)
         rm -f /etc/default/{{package_install_name}}
-
-        # ensure we remove the rc.d scripts installed by postinst
-        update-rc.d {{package_install_name}} remove >/dev/null
-
         if [ -d /var/log/{{package_install_name}} ]; then
                 rm -r /var/log/{{package_install_name}}
         fi

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -32,21 +32,7 @@ install: build
 	dh_testroot
 	dh_prep
 	dh_installdirs
-
-	cp -R rel/{{package_install_name}}/lib \
-              debian/{{package_name}}/usr/lib/{{package_install_name}}
-
-	cp -R rel/{{package_install_name}}/erts* \
-              debian/{{package_name}}/usr/lib/{{package_install_name}}
-
-	cp -R rel/{{package_install_name}}/releases \
-              debian/{{package_name}}/usr/lib/{{package_install_name}}
-
-## executables
-	if [ -d rel/{{package_install_name}}/bin ]; then \
-	    mkdir -p debian/{{package_name}}/usr/{{bin_or_sbin}} && \
-	    {{#package_commands}}install -p -D -m 0755 rel/{{package_install_name}}/bin/{{name}} debian/{{package_name}}/usr/{{bin_or_sbin}}/ && \
-	    {{/package_commands}}echo -n; fi
+	dh_install
 
 ## install man pages if they exist
 	if [ -d doc/man/man1 ]; then \
@@ -56,14 +42,6 @@ install: build
                                              debian/{{package_name}}/usr/share/man/man1/ \
                                  ; fi && \
 	    {{/package_commands}}echo -n; fi
-
-	mkdir -p debian/{{package_name}}/etc/{{package_install_name}}
-	cp -R rel/{{package_install_name}}/etc/* \
-              debian/{{package_name}}/etc/{{package_install_name}}
-
-	mkdir -p debian/{{package_name}}/var/lib
-	cp -R rel/{{package_install_name}}/data/* \
-              debian/{{package_name}}/var/lib/{{package_install_name}}
 
 	install -m755 debian/init.script \
               debian/{{package_name}}/etc/init.d/{{package_install_name}}

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -11,6 +11,7 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
+ROOTDIR := debian/{{package_name}}
 
 ## Clear variables that may confound our build of sub-projects; also
 ## note that it is necessary to use overlay_vars relative to .. as
@@ -27,6 +28,7 @@ clean:
 
 ## dh_shlibdeps was added to figure out the dependencies on shared libraries
 ##   and will populate the ${shlibs:Depends} callout in the control file
+install: LIBDIR := $(ROOTDIR)/usr/lib/{{package_install_name}}
 install: build
 	dh_testdir
 	dh_testroot
@@ -35,6 +37,15 @@ install: build
 	dh_install
 	dh_installman
 	dh_installinit --name={{package_install_name}} --no-start
+	dh_fixperms
+	chmod 0755 $(ROOTDIR)/etc/{{package_install_name}}
+	chmod -R a+rX $(ROOTDIR)/etc/{{package_install_name}}
+	for file in lib/env.sh lib/app_epath.sh erts-*/bin/nodetool; do \
+		if [ -f $(LIBDIR)/$$file ]; then \
+			chmod 0755 $(LIBDIR)/$$file; \
+		fi; \
+	done
+	chmod -R go+rX debian/{{package_name}}/usr/lib/{{package_install_name}}/lib/
 	dh_shlibdeps
 
 # We have nothing to do by default.

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -34,10 +34,7 @@ install: build
 	dh_installdirs
 	dh_install
 	dh_installman
-
-	install -m755 debian/init.script \
-              debian/{{package_name}}/etc/init.d/{{package_install_name}}
-
+	dh_installinit --name={{package_install_name}} --no-start
 	dh_shlibdeps
 
 # We have nothing to do by default.

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -33,15 +33,7 @@ install: build
 	dh_prep
 	dh_installdirs
 	dh_install
-
-## install man pages if they exist
-	if [ -d doc/man/man1 ]; then \
-	    mkdir -p debian/usr/share/man/man1 && \
-	    {{#package_commands}}if [ -f doc/man/man1/{{name}}.1.gz ]; then \
-                                     install -p -D -m 0544 doc/man/man1/{{name}}.1.gz \
-                                             debian/{{package_name}}/usr/share/man/man1/ \
-                                 ; fi && \
-	    {{/package_commands}}echo -n; fi
+	dh_installman
 
 	install -m755 debian/init.script \
               debian/{{package_name}}/etc/init.d/{{package_install_name}}


### PR DESCRIPTION
Cleanup the deb template to use the debhelper scripts when possible. This greatly simplifies the rules file and ensures that things like man pages are installed correctly w/ proper permissions.

In addition, as /var/run is a tmpfs in recent Debian releases, avoid installing to this directory and instead create the runtime directory dynamically.

Finally, add a systemd unit file which will automatically be installed by dh_installinit when needed.

These changes have been tested with riak_ee on debian 8 as well as debian 7 to ensure backwards compatibility with non-systemd releases.
