### PR TITLE
Use POSIX compatible shell and tools on Solaris

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -4,17 +4,6 @@
 
 # installed by node_package (github.com/basho/node_package)
 
-# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
-if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
-    POSIX_SHELL="true"
-    export POSIX_SHELL
-    # To support 'whoami' add /usr/ucb to path
-    PATH=/usr/ucb:$PATH
-    export PATH
-    exec /usr/bin/ksh $0 "$@"
-fi
-unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
-
 RUNNER_SCRIPT_DIR={{runner_script_dir}}
 RUNNER_SCRIPT=${0##*/}
 

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -4,6 +4,17 @@
 
 # installed by node_package (github.com/basho/node_package)
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/xpg4/bin/sh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    # Add posix compatible binaries to the PATH
+    PATH=`getconf PATH`:$PATH
+    export PATH
+    exec /usr/xpg4/bin/sh $0 "$@"
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as /usr/xpg4/bin/sh as well
+
 # Pull environment for this install
 . "{{runner_base_dir}}/lib/env.sh"
 


### PR DESCRIPTION
The runner (a.k.a riak, riak-cs, etc) script sourced
`env.sh` early on, before pivoting to running in a POSIX
compliant shell. Pivoting first, and sourcing `env.sh` afterwards
allows us to write the remainder of the script and any sourced
scripts in a POSIX compliant way without breaking execution on
Solaris 10.
