### PR TITLE
Fix permissions before building package on Solaris

### DIFF
--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -27,6 +27,13 @@ buildrel:
 	@# Ye Olde Bourne Shell on Solaris means we have to do it old school
 	echo "Using `which erl` to build"; \
 	OVERLAY_VARS="overlay_vars=../solaris/vars.config" $(MAKE) rel
+	chmod -R go+rX rel/{{package_install_name}}
+	chmod 0755 rel/{{package_install_name}}/etc
+	chmod -R a+rX rel/{{package_install_name}}/etc
+	chmod 0755 rel/{{package_install_name}}/lib/env.sh
+	chmod 0755 rel/{{package_install_name}}/lib/app_epath.sh
+	chmod 0755 rel/{{package_install_name}}/erts-*/bin/nodetool
+	chmod -R go+rX rel/{{package_install_name}}/lib/
 	chmod 0755 rel/{{package_install_name}}/bin/* \
 		rel/{{package_install_name}}/erts-*/bin/*
 	if [ "{{bin_or_sbin}}" != "bin" ]; then \


### PR DESCRIPTION
The `pkgproto` tool on Solaris (like many other OSes) uses the filesystem permissions of the template installation on disk as the desired install permissions. Due to a strict (`0077`) umask set on some of our build infrastructure, many of the files/directories in the package did not have the appropriate permissions, even though testing before build on other Solaris machines (with less-restrictive umask settings) showed the correct permissions.

This PR sets the filesystem permissions correctly in the `rel` directory before running `pkgproto` so that it picks up the correct permissions.

This resolves #206 (TOOLS-345).
