### PR TITLE
Fix RIAK-2702 by restricting possible atom usage to 1000

### DIFF
--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -189,7 +189,7 @@ nodename(Name) ->
     end.
 
 append_node_suffix(Name, Suffix) ->
-    random:seed(os:getpid()),
+    random:seed(os:timestamp()),
     case string:tokens(Name, "@") of
         [Node, Host] ->
             list_to_atom(lists:concat([Node, Suffix, random:uniform(1000), "@", Host]));

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -189,6 +189,7 @@ nodename(Name) ->
     end.
 
 append_node_suffix(Name, Suffix) ->
+    random:seed(os:getpid()),
     case string:tokens(Name, "@") of
         [Node, Host] ->
             list_to_atom(lists:concat([Node, Suffix, random:uniform(1000), "@", Host]));

--- a/priv/base/nodetool
+++ b/priv/base/nodetool
@@ -191,9 +191,9 @@ nodename(Name) ->
 append_node_suffix(Name, Suffix) ->
     case string:tokens(Name, "@") of
         [Node, Host] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid(), "@", Host]));
+            list_to_atom(lists:concat([Node, Suffix, random:uniform(1000), "@", Host]));
         [Node] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid()]))
+            list_to_atom(lists:concat([Node, Suffix, random:uniform(1000)]))
     end.
 
 chkconfig(File) ->

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -363,7 +363,7 @@ case "$1" in
         node_up_check
 
         shift
-        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
+        RAND=$(($(($RANDOM % 1000)) + 1))
         NODE_NAME=${NAME_ARG#* }
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_PATCH_DIR \

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -306,8 +306,9 @@ case "$1" in
         echo "Remote Shell: Use \"Ctrl-G q\" to quit."
         echo "q() or init:stop() will terminate the $SCRIPT node."
         shift
+        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
         NODE_NAME=${NAME_ARG#* }
-        exec $ERTS_PATH/erl -name c_$$_$NODE_NAME -hidden -remsh $NODE_NAME $COOKIE_ARG $NET_TICKTIME_ARG
+        exec $ERTS_PATH/erl -name c_$RAND_$NODE_NAME -hidden -remsh $NODE_NAME $COOKIE_ARG $NET_TICKTIME_ARG
         ;;
 
     console)
@@ -362,11 +363,11 @@ case "$1" in
         node_up_check
 
         shift
-        MYPID=$$
+        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
         NODE_NAME=${NAME_ARG#* }
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_PATCH_DIR \
-            -hidden $NAME_PARAM np_etop$MYPID$NAME_HOST $COOKIE_ARG $NET_TICKTIME_ARG \
+            -hidden $NAME_PARAM riak_etop$RAND$NAME_HOST $COOKIE_ARG $NET_TICKTIME_ARG \
             -s etop -s erlang halt -output text \
             -node $NODE_NAME \
             $* -tracing off

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -306,7 +306,7 @@ case "$1" in
         echo "Remote Shell: Use \"Ctrl-G q\" to quit."
         echo "q() or init:stop() will terminate the $SCRIPT node."
         shift
-        RAND=$(bc <<< "$(($(($RANDOM % 1000)) + 1))")
+        RAND=$(($(($RANDOM % 1000)) + 1))
         NODE_NAME=${NAME_ARG#* }
         exec $ERTS_PATH/erl -name c_$RAND_$NODE_NAME -hidden -remsh $NODE_NAME $COOKIE_ARG $NET_TICKTIME_ARG
         ;;
@@ -367,7 +367,7 @@ case "$1" in
         NODE_NAME=${NAME_ARG#* }
         $ERTS_PATH/erl -noshell -noinput \
             -pa $RUNNER_PATCH_DIR \
-            -hidden $NAME_PARAM riak_etop$RAND$NAME_HOST $COOKIE_ARG $NET_TICKTIME_ARG \
+            -hidden $NAME_PARAM np_etop$RAND$NAME_HOST $COOKIE_ARG $NET_TICKTIME_ARG \
             -s etop -s erlang halt -output text \
             -node $NODE_NAME \
             $* -tracing off


### PR DESCRIPTION
We were using the OS PID as a pseudo random number generator but the range is too large since each node name used would generate an entry in the atom table.  Restrict the possible atoms used by `riak` and `riak-admin` commands to 1000.  Also, change node name used by `riak top` to match `riak-admin top` convention.