### PR TITLE
Revert "Set NODETOOL up as an alias and include ERL_FLAGS env vars"

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -124,12 +124,8 @@ APP_VSN=${START_ERL#* }
 ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
-if [ -f $RUNNER_ETC_DIR/vm.args ]; then
-    SSL_ARGS=$(grep -e '^\-ssl_dist_opt' -e '^\-proto_dist' $RUNNER_ETC_DIR/vm.args | tr '\n' ' ')
-    ERL_FLAGS="$ERL_FLAGS $SSL_ARGS"
-fi
-alias NODETOOL="ERL_FLAGS=\"$ERL_FLAGS\" $ERTS_PATH/escript $ERTS_PATH/nodetool $NET_TICKTIME_ARG $NAME_ARG $COOKIE_ARG"
-alias NODETOOL_LITE="ERL_FLAGS=\"$ERL_FLAGS\" $ERTS_PATH/escript $ERTS_PATH/nodetool"
+NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NET_TICKTIME_ARG $NAME_ARG $COOKIE_ARG"
+NODETOOL_LITE="$ERTS_PATH/escript $ERTS_PATH/nodetool"
 
 
 ## Are we using cuttlefish (http://github.com/basho/cuttlefish)
@@ -144,7 +140,7 @@ fi
 
 # Ping node without stealing stdin
 ping_node() {
-    NODETOOL ping < /dev/null
+    $NODETOOL ping < /dev/null
 }
 
 # Attempts to create a pid directory like /var/run/APPNAME and then
@@ -299,7 +295,7 @@ check_config() {
         fi
     fi
 
-    MUTE=`NODETOOL_LITE chkconfig $CONFIG_ARGS`
+    MUTE=`$NODETOOL_LITE chkconfig $CONFIG_ARGS`
     if [ "$?" -ne 0 ]; then
         echoerr "Error reading $CONFIG_ARGS"
         exit 1
@@ -324,7 +320,7 @@ check_ulimit() {
 
 # Set the PID global variable, return 1 on error
 get_pid() {
-    PID=`NODETOOL getpid < /dev/null`
+    PID=`$NODETOOL getpid < /dev/null`
     if [ "$?" -ne 0 ]; then
         echo "Node is not running!"
         return 1

--- a/priv/base/runner
+++ b/priv/base/runner
@@ -205,7 +205,7 @@ do_start() {
             if [ "$?" -ne 0 ]; then
                 continue
             fi
-            PROCESS=`NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
+            PROCESS=`$NODETOOL rpcterms erlang whereis "'${WAIT_FOR_PROCESS}'."`
             if [ "$PROCESS" != "undefined" ]; then
                 # Attempt to create a .pid file for the process
                 create_pid_file
@@ -231,7 +231,7 @@ do_stop() {
     fi
 
     # Tell nodetool to stop
-    NODETOOL stop
+    $NODETOOL stop
     ES=$?
     if [ "$ES" -ne 0 ]; then
         exit $ES


### PR DESCRIPTION
Further thinking made me realize this would break many existing non-riak scripts which others users rely on. Going to handle this the same way we handle net_ticktime argument.

Reverts basho/node_package#183 (TOOLS-114)