### PR TITLE
Fix for Solaris10 sh

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -125,7 +125,7 @@ ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
 if [ -f $RUNNER_ETC_DIR/vm.args ]; then
-    SSL_ARGS=$(grep -e '^\-ssl_dist_opt' -e '^\-proto_dist' $RUNNER_ETC_DIR/vm.args | tr '\n' ' ')
+    SSL_ARGS=`grep -e '^\-ssl_dist_opt' -e '^\-proto_dist' $RUNNER_ETC_DIR/vm.args | tr '\n' ' '`
     ERL_FLAGS="$ERL_FLAGS $SSL_ARGS"
 fi
 alias NODETOOL="ERL_FLAGS=\"$ERL_FLAGS\" $ERTS_PATH/escript $ERTS_PATH/nodetool $NET_TICKTIME_ARG $NAME_ARG $COOKIE_ARG"
@@ -144,7 +144,10 @@ fi
 
 # Ping node without stealing stdin
 ping_node() {
-    NODETOOL ping < /dev/null
+    output=`NODETOOL ping < /dev/null`
+    status=$?
+    echo $output
+    return $status
 }
 
 # Attempts to create a pid directory like /var/run/APPNAME and then


### PR DESCRIPTION
Commit 44a4f19ecc5c7b7131c04a9c391391b46ee03ae3 uses $(command) notation
to populate SSL_ARGS. This notation is not supported by Solaris10 sh.

Use backticks instead.

Ksh expands aliases containing '=' differently from bash, but seems
to work fine when an alias is evaluated inside backticks. Call NODETOOL
inside backticks consistently throughout the file.