### PR TITLE
Allow check_pid_status to differentiate similar names

### DIFF
--- a/priv/templates/rpm/rhel.init.script
+++ b/priv/templates/rpm/rhel.init.script
@@ -40,7 +40,7 @@ status -p $pidfile -l $(basename $lockfile) $NAME >/dev/null 2>&1
 running=$?
 
 check_pid_status() {
-    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME " | awk '{print $1}')
     if [ "$pid" = "" ]; then
         # prog not running?
         return 1

--- a/priv/templates/rpm/suse.init.script
+++ b/priv/templates/rpm/suse.init.script
@@ -44,7 +44,7 @@ do_status() {
 }
 
 check_pid_status() {
-    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME" | awk '{print $1}')
+    pid=$(ps ax | grep beam.smp | grep "\-progname $NAME " | awk '{print $1}')
     if [ "$pid" = "" ]; then
         # prog not running?
         return 1


### PR DESCRIPTION
Without a trailing space in the grep command, two different programs
with the same prefix (e.g. riak and riak-cs) will be confused. In
this example, if riak and riak-cs are configured to run on the same
server the riak init script will incorrectly say that it is running
in the situation where riak is stopped and riak-cs is running.

Also, compare to the grep line in hardstop (which already has the
trailing space).