### PR TITLE
Added support for Amazon Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,15 @@ DEPS_DIR     ?= deps
 ifeq ($(OS),Linux)
 ARCH          = $(shell uname -m)
 ISRPM         = $(shell cat /etc/redhat-release 2> /dev/null)
+ISARPM        = $(shell cat /etc/system-release 2> /dev/null)
 ISDEB         = $(shell cat /etc/debian_version 2> /dev/null)
 ISSLES        = $(shell cat /etc/SuSE-release 2> /dev/null)
 ifneq ($(ISRPM),)
+OSNAME        = RedHat
+PKGERDIR      = rpm
+BUILDDIR      = rpmbuild
+else
+ifneq ($(ISARPM),)
 OSNAME        = RedHat
 PKGERDIR      = rpm
 BUILDDIR      = rpmbuild
@@ -31,6 +37,7 @@ PKGERDIR      = rpm
 BUILDDIR      = rpmbuild
 endif  # SLES
 endif  # deb
+endif  # amazon
 endif  # rpm
 endif  # linux
 


### PR DESCRIPTION
Although Amazon Linux is based off RedHat/CentOS and uses the same rpm build structure, for some reason they changed `/etc/redhat-release` to `/etc/system-release`. As this is not a recognised structure, the Riak build fails, claiming it does not know what to do with "Linux". This pull request is designed to get around that and allow Amazon Linux to build as if it were RedHat/CentOS.

This issue affects all versions of node_package. Would it be at all possible to `git cherry-pick` this in to multiple versions and tags, please? Especially tags 4.0.2 (KV 2.2.6 and KV 2.9.0) and 3.0.0 (CS 2.1.2 and Stanchion 2.1.2).